### PR TITLE
Move google_api_key to ENV var

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,8 +3,6 @@ class UsersController < ApplicationController
 
   before_action :set_user, only: [:show, :edit, :update]
 
-  before_action :set_vars
-
   # GET /users/1
   # GET /users/1.json
   def show
@@ -107,11 +105,5 @@ class UsersController < ApplicationController
         format.json { render json: @user.errors, status: :unprocessable_entity }
       end
     end
-  end
-
-  private
-
-  def set_vars
-    @google_api_key = ENV['GOOGLE_API_KEY']
   end
 end

--- a/config/initializers/google.rb
+++ b/config/initializers/google.rb
@@ -1,2 +1,0 @@
-# This key is tied to john@fnnny.com, needs the Google Places Web API enabled
-ENV['GOOGLE_API_KEY'] = 'AIzaSyCp4DCD46mbNzHNld5EM6d1_COhIAb7RAk'


### PR DESCRIPTION
Since @google_api_key was an instance var only in #edit, and an validation error is the #update method, the rendered edit view would have nil for Google API key.

This way sets it for all methods in this controller.
