### PR TITLE
extend timeout for local dev so we can use breakpoints

### DIFF
--- a/config/initializers/general.rb
+++ b/config/initializers/general.rb
@@ -1,0 +1,3 @@
+# https://github.com/heroku/rack-timeout
+# extend timeout for local dev so we can use breakpoints without service resetting
+Rack::Timeout.service_timeout = 3600 if Rails.env.development? # seconds


### PR DESCRIPTION
Otherwise, service will reset while stepping through with byebug
