### PR TITLE
Issue #140 scaled simulation using parallel threads

### DIFF
--- a/app/controllers/admin/simulations_controller.rb
+++ b/app/controllers/admin/simulations_controller.rb
@@ -21,7 +21,7 @@ class Admin::SimulationsController < Admin::AdminApplicationController
     if Simulation.can_start_new?
       @simulation = Simulation.create_named_sim(params[:slug])
       @simulation.play
-      flash[:notice] = 'Simulation running'
+      flash[:notice] = 'Simulation preparing'
     else
       flash[:notice] = 'Simulation already in progress'
     end

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -124,13 +124,15 @@ class Conversation < ApplicationRecord
 
   private
   def notify_creation
-    self.ride_zone.event(:new_conversation, self) if self.ride_zone
+    rz_id = self.ride_zone_id || self.ride_zone.try(:id)
+    RideZone.event(rz_id, :new_conversation, self) if rz_id
   end
 
   def notify_update
     was_new = new_record?
     yield
-    self.ride_zone.event(:conversation_changed, self) if !was_new && self.ride_zone
+    rz_id = self.ride_zone_id || self.ride_zone.try(:id)
+    RideZone.event(rz_id, :conversation_changed, self) if !was_new && rz_id
   end
 
   def check_ride_attached

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -78,8 +78,9 @@ class Message < ApplicationRecord
 
   private
   def notify_creation
-    self.ride_zone.event(:new_message, self) if self.ride_zone
-    self.ride_zone.event(:conversation_changed, self.conversation) if self.ride_zone
+    rz_id = self.ride_zone_id || self.ride_zone.try(:id)
+    RideZone.event(rz_id, :new_message, self) if rz_id
+    RideZone.event(rz_id, :conversation_changed, self.conversation) if rz_id
   end
 
   def conversation_has_correct_phone_numbers
@@ -93,6 +94,7 @@ class Message < ApplicationRecord
   def notify_update
     was_new = new_record?
     yield
-    self.ride_zone.event(:message_changed, self) if !was_new && self.ride_zone
+    rz_id = self.ride_zone_id || self.ride_zone.try(:id)
+    RideZone.event(rz_id, :message_changed, self) if !was_new && rz_id
   end
 end

--- a/app/models/ride.rb
+++ b/app/models/ride.rb
@@ -139,9 +139,12 @@ class Ride < ApplicationRecord
     new_driver = self.driver
     notify_old_driver = old_driver != new_driver
     yield
-    self.ride_zone.event(:conversation_changed, self.conversation) if !was_new && self.ride_zone && self.conversation
-    self.ride_zone.event(:driver_changed, old_driver, :driver) if notify_old_driver && old_driver && self.ride_zone
-    self.ride_zone.event(:driver_changed, new_driver, :driver) if new_driver && self.ride_zone
+    rz_id = self.ride_zone_id || self.ride_zone.try(:id)
+    if rz_id
+      RideZone.event(rz_id, :conversation_changed, self.conversation) if !was_new && self.conversation
+      RideZone.event(rz_id, :driver_changed, old_driver, :driver) if notify_old_driver && old_driver
+      RideZone.event(rz_id, :driver_changed, new_driver, :driver) if new_driver
+    end
   end
 
   def close_conversation_when_complete

--- a/app/models/ride_zone.rb
+++ b/app/models/ride_zone.rb
@@ -64,13 +64,13 @@ class RideZone < ApplicationRecord
 
   # call this to broadcast an event for this ride zone
   # the object must respond to :api_json
-  def event(event_type, object, tag = nil)
+  def self.event(rz_id, event_type, object, tag = nil)
     event = {
       event_type: event_type,
       timestamp: Time.now.to_i,
       tag || object.class.name.downcase => object.send(:api_json)
     }
-    ActionCable.server.broadcast "ride_zone_#{self.id}", event
+    ActionCable.server.broadcast "ride_zone_#{rz_id}", event
   end
 
   def set_time_zone

--- a/app/models/sim_definition.rb
+++ b/app/models/sim_definition.rb
@@ -17,7 +17,7 @@ class SimDefinition
     @name = @data['name']
     @ride_zone_data = @data['ride_zone']
     @ride_zone_name = @ride_zone_data['name']
-    @drivers = @data['drivers'] || []
+    create_drivers
     @voters = @data['voters'] || []
     @rides = @data['rides'] || []
     @user_identifier = @data['user_identifier']
@@ -44,6 +44,24 @@ class SimDefinition
   end
 
   private
+  def create_drivers
+    @drivers = []
+    (@data['drivers'] || []).each_with_index do |info, i|
+      count = info['count'] || 1
+      time_jitter = info['time_jitter'] || 0
+      loc_jitter = info['loc_jitter'] || 0
+      raise "bad driver #{i} info" unless info['events'][0]['type'] == 'move'
+      count.times do
+        driver = info.deep_dup
+        first_move = driver['events'][0]
+        first_move['at'] = first_move['at'] + ((rand(100).to_f/100.0) * time_jitter)
+        first_move['lat'] = first_move['lat'] + ((rand(100).to_f/100.0) * loc_jitter)
+        first_move['lng'] = first_move['lng'] + ((rand(100).to_f/100.0) * loc_jitter)
+        @drivers << driver
+      end
+    end
+  end
+
   def calc_run_time
     max_time = 0
     @drivers.each do |driver|

--- a/app/views/admin/simulations/index.html.haml
+++ b/app/views/admin/simulations/index.html.haml
@@ -4,7 +4,7 @@
   Simulations
 - if Simulation.can_start_new?
   .row
-    .col-md-2
+    .col-md-4
       = form_tag start_new_admin_simulations_url, method: :POST do
         = select_tag "slug", options_from_collection_for_select(@simulation_defs, "slug", "name"), include_blank: false
         %br
@@ -29,22 +29,27 @@
       %tr
         %td= sim.id
         %td= sim.name
-        %td= sim.status
+        %td{id: "sim-status-#{sim.id}"}= sim.status
         %td= sim.created_at.localtime.strftime('%l:%M %P')
-        %td= sim.run_time
+        %td= "#{(sim.run_time/60).floor}:%02d" % (sim.run_time % 60)
         %td.sim_latest_event{id: "sim-event-#{sim.id}"}
         %td
           - if sim.active?
             = link_to 'Stop', stop_admin_simulation_path(sim), class: 'btn btn-default btn-xs', data: { confirm: 'Are you sure?' }, method: :POST
-          - elsif sim.status == 'completed'
+          - elsif sim.status == 'completed' || sim.status == 'failed'
             = link_to 'Delete', delete_admin_simulation_path(sim), class: 'btn btn-default btn-xs', data: { confirm: 'Are you sure?' }, method: :DELETE
 
 :javascript
   createSimulationChannel(simEvent)
 
   function simEvent(data) {
-    if (data.type == 'complete') {
-      location.reload(true)
+    if (data.type == 'status') {
+      if (data.status == 'complete')
+        location.reload(true);
+      else {
+        jQuery('#sim-status-'+data.id).text(data.status)
+        jQuery('#sim-event-'+data.id).text('')
+      }
     } else if (data.type == 'event') {
       jQuery('#sim-event-'+data.id).text(data.name)
     }

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,7 +2,7 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  pool: 5
+  pool: 40
   timeout: 5000
   username: postgres
   password: admin

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -51,9 +51,7 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
-  config.log_level = :debug
+  config.log_level = :warn
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]

--- a/data/simulations/load1_sim.yaml
+++ b/data/simulations/load1_sim.yaml
@@ -1,0 +1,93 @@
+slug: 'loadtest1'
+name: "Test 200 drivers @15 seconds"
+user_identifier: "(dp)"
+ride_zone:
+  name: 'Florida 5th CD'
+  slug: 'florida-5th-cd'
+  zip: '32805'
+  phone_number: '+15555550001'
+  latitude: 28.533609
+  longitude: -81.406011
+  time_zone: 'America/New_York'
+drivers:
+  - count: 200
+    time_jitter: 300
+    loc_jitter: 0.060
+    events:
+      - {at: 4, type: move, lat: 28.541, lng: -81.412 }
+      - {at: "+15", repeat_count: 30, repeat_time: 15, type: move_by, lat: 0.001, lng: 0.001 }
+
+voters:
+  -
+    events:
+      - {at: 10, type: sms, body: "hi can i get a ride"}
+      - {at: "+3", type: sms, body: "1"}
+      - {at: "+5", type: sms, body: "<USERNAME>"}
+      - {at: "+10", type: sms, body: "700 ohio avenue orlando"}
+      - {at: "+5", type: sms, body: "yes"}
+      - {at: "+10", type: sms, body: "3099 Orange Center Blvd, Orlando"}
+      - {at: "+5", type: sms, body: "yes"}
+      - {at: "+7", type: sms, time_offset: "15 minutes"}
+      - {at: "+5", type: sms, body: "yes"}
+      - {at: "+5", type: sms, body: "none"}
+      - {at: "+5", type: sms, body: "none"}
+  -
+    events:
+      - {at: 20, type: sms, body: "hola"}
+      - {at: "+3", type: sms, body: "2"}
+      - {at: "+5", type: sms, body: "<USERNAME>"}
+      - {at: "+10", type: sms, body: "1832 horne ave orlando"}
+      - {at: "+5", type: sms, body: "si"}
+      - {at: "+5", type: sms, body: "no se"}
+      - {at: "+5", type: sms, time_offset: "ahora"}
+      - {at: "+5", type: sms, body: "si"}
+      - {at: "+5", type: sms, body: "1"}
+      - {at: "+5", type: sms, body: "nada"}
+  -
+    events:
+      - {at: 30, type: sms, body: "is this for rides?"}
+      - {at: "+5", type: sms, body: "1"}
+      - {at: "+5", type: sms, body: "<USERNAME>"}
+      - {at: "+10", type: sms, body: "ermas day care orlando"}
+      - {at: "+5", type: sms, body: "yes"}
+      - {at: "+14", type: sms, body: "i'm not really sure"}
+      - {at: "+5", type: sms, body: "wut?"}
+      - {at: "+5", type: sms, body: "skip"}
+      - {at: "+7", type: sms, time_offset: "45 minutes"}
+      - {at: "+5", type: sms, body: "yes"}
+      - {at: "+3", type: sms, body: "0"}
+      - {at: "+3", type: sms, body: "none"}
+
+rides:
+  -
+    pickup_offset: "-5 minutes"
+    from_address: "624 Doby Avenue"
+    from_city: "orlando"
+    from_latitude: 28.534
+    from_longitude: -81.407
+    additional_passengers: 0
+    special_requests: none
+  -
+    pickup_offset: "-15 minutes"
+    from_address: "3337 Rogers Drive"
+    from_city: "orlando"
+    from_latitude: 28.531146
+    from_longitude: -81.419256
+    additional_passengers: 0
+    special_requests: none
+  -
+    pickup_offset: "15 minutes"
+    from_address: "1140 Martin L King Dr"
+    from_city: "orlando"
+    from_latitude: 28.5327758
+    from_longitude: -81.412722
+    additional_passengers: 0
+    special_requests: none
+  -
+    pickup_offset: "30 minutes"
+    from_address: "2001 West South Street"
+    from_city: "orlando"
+    from_latitude: 28.538499
+    from_longitude: -81.405609
+    additional_passengers: 0
+    special_requests: none

--- a/data/simulations/load2_sim.yaml
+++ b/data/simulations/load2_sim.yaml
@@ -1,0 +1,93 @@
+slug: 'loadtest2'
+name: "Test 400 drivers @15 seconds"
+user_identifier: "(dp)"
+ride_zone:
+  name: 'Florida 5th CD'
+  slug: 'florida-5th-cd'
+  zip: '32805'
+  phone_number: '+15555550001'
+  latitude: 28.533609
+  longitude: -81.406011
+  time_zone: 'America/New_York'
+drivers:
+  - count: 400
+    time_jitter: 300
+    loc_jitter: 0.060
+    events:
+      - {at: 4, type: move, lat: 28.541, lng: -81.412 }
+      - {at: "+15", repeat_count: 30, repeat_time: 15, type: move_by, lat: 0.001, lng: 0.001 }
+
+voters:
+  -
+    events:
+      - {at: 10, type: sms, body: "hi can i get a ride"}
+      - {at: "+3", type: sms, body: "1"}
+      - {at: "+5", type: sms, body: "<USERNAME>"}
+      - {at: "+10", type: sms, body: "700 ohio avenue orlando"}
+      - {at: "+5", type: sms, body: "yes"}
+      - {at: "+10", type: sms, body: "3099 Orange Center Blvd, Orlando"}
+      - {at: "+5", type: sms, body: "yes"}
+      - {at: "+7", type: sms, time_offset: "15 minutes"}
+      - {at: "+5", type: sms, body: "yes"}
+      - {at: "+5", type: sms, body: "none"}
+      - {at: "+5", type: sms, body: "none"}
+  -
+    events:
+      - {at: 20, type: sms, body: "hola"}
+      - {at: "+3", type: sms, body: "2"}
+      - {at: "+5", type: sms, body: "<USERNAME>"}
+      - {at: "+10", type: sms, body: "1832 horne ave orlando"}
+      - {at: "+5", type: sms, body: "si"}
+      - {at: "+5", type: sms, body: "no se"}
+      - {at: "+5", type: sms, time_offset: "ahora"}
+      - {at: "+5", type: sms, body: "si"}
+      - {at: "+5", type: sms, body: "1"}
+      - {at: "+5", type: sms, body: "nada"}
+  -
+    events:
+      - {at: 30, type: sms, body: "is this for rides?"}
+      - {at: "+5", type: sms, body: "1"}
+      - {at: "+5", type: sms, body: "<USERNAME>"}
+      - {at: "+10", type: sms, body: "ermas day care orlando"}
+      - {at: "+5", type: sms, body: "yes"}
+      - {at: "+14", type: sms, body: "i'm not really sure"}
+      - {at: "+5", type: sms, body: "wut?"}
+      - {at: "+5", type: sms, body: "skip"}
+      - {at: "+7", type: sms, time_offset: "45 minutes"}
+      - {at: "+5", type: sms, body: "yes"}
+      - {at: "+3", type: sms, body: "0"}
+      - {at: "+3", type: sms, body: "none"}
+
+rides:
+  -
+    pickup_offset: "-5 minutes"
+    from_address: "624 Doby Avenue"
+    from_city: "orlando"
+    from_latitude: 28.534
+    from_longitude: -81.407
+    additional_passengers: 0
+    special_requests: none
+  -
+    pickup_offset: "-15 minutes"
+    from_address: "3337 Rogers Drive"
+    from_city: "orlando"
+    from_latitude: 28.531146
+    from_longitude: -81.419256
+    additional_passengers: 0
+    special_requests: none
+  -
+    pickup_offset: "15 minutes"
+    from_address: "1140 Martin L King Dr"
+    from_city: "orlando"
+    from_latitude: 28.5327758
+    from_longitude: -81.412722
+    additional_passengers: 0
+    special_requests: none
+  -
+    pickup_offset: "30 minutes"
+    from_address: "2001 West South Street"
+    from_city: "orlando"
+    from_latitude: 28.538499
+    from_longitude: -81.405609
+    additional_passengers: 0
+    special_requests: none

--- a/data/simulations/load3_sim.yaml
+++ b/data/simulations/load3_sim.yaml
@@ -1,0 +1,93 @@
+slug: 'loadtest3'
+name: "Test 600 drivers @15 seconds"
+user_identifier: "(dp)"
+ride_zone:
+  name: 'Florida 5th CD'
+  slug: 'florida-5th-cd'
+  zip: '32805'
+  phone_number: '+15555550001'
+  latitude: 28.533609
+  longitude: -81.406011
+  time_zone: 'America/New_York'
+drivers:
+  - count: 600
+    time_jitter: 300
+    loc_jitter: 0.060
+    events:
+      - {at: 4, type: move, lat: 28.541, lng: -81.412 }
+      - {at: "+15", repeat_count: 30, repeat_time: 15, type: move_by, lat: 0.001, lng: 0.001 }
+
+voters:
+  -
+    events:
+      - {at: 10, type: sms, body: "hi can i get a ride"}
+      - {at: "+3", type: sms, body: "1"}
+      - {at: "+5", type: sms, body: "<USERNAME>"}
+      - {at: "+10", type: sms, body: "700 ohio avenue orlando"}
+      - {at: "+5", type: sms, body: "yes"}
+      - {at: "+10", type: sms, body: "3099 Orange Center Blvd, Orlando"}
+      - {at: "+5", type: sms, body: "yes"}
+      - {at: "+7", type: sms, time_offset: "15 minutes"}
+      - {at: "+5", type: sms, body: "yes"}
+      - {at: "+5", type: sms, body: "none"}
+      - {at: "+5", type: sms, body: "none"}
+  -
+    events:
+      - {at: 20, type: sms, body: "hola"}
+      - {at: "+3", type: sms, body: "2"}
+      - {at: "+5", type: sms, body: "<USERNAME>"}
+      - {at: "+10", type: sms, body: "1832 horne ave orlando"}
+      - {at: "+5", type: sms, body: "si"}
+      - {at: "+5", type: sms, body: "no se"}
+      - {at: "+5", type: sms, time_offset: "ahora"}
+      - {at: "+5", type: sms, body: "si"}
+      - {at: "+5", type: sms, body: "1"}
+      - {at: "+5", type: sms, body: "nada"}
+  -
+    events:
+      - {at: 30, type: sms, body: "is this for rides?"}
+      - {at: "+5", type: sms, body: "1"}
+      - {at: "+5", type: sms, body: "<USERNAME>"}
+      - {at: "+10", type: sms, body: "ermas day care orlando"}
+      - {at: "+5", type: sms, body: "yes"}
+      - {at: "+14", type: sms, body: "i'm not really sure"}
+      - {at: "+5", type: sms, body: "wut?"}
+      - {at: "+5", type: sms, body: "skip"}
+      - {at: "+7", type: sms, time_offset: "45 minutes"}
+      - {at: "+5", type: sms, body: "yes"}
+      - {at: "+3", type: sms, body: "0"}
+      - {at: "+3", type: sms, body: "none"}
+
+rides:
+  -
+    pickup_offset: "-5 minutes"
+    from_address: "624 Doby Avenue"
+    from_city: "orlando"
+    from_latitude: 28.534
+    from_longitude: -81.407
+    additional_passengers: 0
+    special_requests: none
+  -
+    pickup_offset: "-15 minutes"
+    from_address: "3337 Rogers Drive"
+    from_city: "orlando"
+    from_latitude: 28.531146
+    from_longitude: -81.419256
+    additional_passengers: 0
+    special_requests: none
+  -
+    pickup_offset: "15 minutes"
+    from_address: "1140 Martin L King Dr"
+    from_city: "orlando"
+    from_latitude: 28.5327758
+    from_longitude: -81.412722
+    additional_passengers: 0
+    special_requests: none
+  -
+    pickup_offset: "30 minutes"
+    from_address: "2001 West South Street"
+    from_city: "orlando"
+    from_latitude: 28.538499
+    from_longitude: -81.405609
+    additional_passengers: 0
+    special_requests: none

--- a/data/simulations/load4_sim.yaml
+++ b/data/simulations/load4_sim.yaml
@@ -1,0 +1,93 @@
+slug: 'loadtest4'
+name: "Test 800 drivers @60 seconds"
+user_identifier: "(dp)"
+ride_zone:
+  name: 'Florida 5th CD'
+  slug: 'florida-5th-cd'
+  zip: '32805'
+  phone_number: '+15555550001'
+  latitude: 28.533609
+  longitude: -81.406011
+  time_zone: 'America/New_York'
+drivers:
+  - count: 800
+    time_jitter: 100
+    loc_jitter: 0.12
+    events:
+      - {at: 4, type: move, lat: 28.541, lng: -81.412 }
+      - {at: "+15", repeat_count: 15, repeat_time: 60, type: move_by, lat: 0.001, lng: 0.001 }
+
+voters:
+  -
+    events:
+      - {at: 10, type: sms, body: "hi can i get a ride"}
+      - {at: "+3", type: sms, body: "1"}
+      - {at: "+5", type: sms, body: "<USERNAME>"}
+      - {at: "+10", type: sms, body: "700 ohio avenue orlando"}
+      - {at: "+5", type: sms, body: "yes"}
+      - {at: "+10", type: sms, body: "3099 Orange Center Blvd, Orlando"}
+      - {at: "+5", type: sms, body: "yes"}
+      - {at: "+7", type: sms, time_offset: "15 minutes"}
+      - {at: "+5", type: sms, body: "yes"}
+      - {at: "+5", type: sms, body: "none"}
+      - {at: "+5", type: sms, body: "none"}
+  -
+    events:
+      - {at: 20, type: sms, body: "hola"}
+      - {at: "+3", type: sms, body: "2"}
+      - {at: "+5", type: sms, body: "<USERNAME>"}
+      - {at: "+10", type: sms, body: "1832 horne ave orlando"}
+      - {at: "+5", type: sms, body: "si"}
+      - {at: "+5", type: sms, body: "no se"}
+      - {at: "+5", type: sms, time_offset: "ahora"}
+      - {at: "+5", type: sms, body: "si"}
+      - {at: "+5", type: sms, body: "1"}
+      - {at: "+5", type: sms, body: "nada"}
+  -
+    events:
+      - {at: 30, type: sms, body: "is this for rides?"}
+      - {at: "+5", type: sms, body: "1"}
+      - {at: "+5", type: sms, body: "<USERNAME>"}
+      - {at: "+10", type: sms, body: "ermas day care orlando"}
+      - {at: "+5", type: sms, body: "yes"}
+      - {at: "+14", type: sms, body: "i'm not really sure"}
+      - {at: "+5", type: sms, body: "wut?"}
+      - {at: "+5", type: sms, body: "skip"}
+      - {at: "+7", type: sms, time_offset: "45 minutes"}
+      - {at: "+5", type: sms, body: "yes"}
+      - {at: "+3", type: sms, body: "0"}
+      - {at: "+3", type: sms, body: "none"}
+
+rides:
+  -
+    pickup_offset: "-5 minutes"
+    from_address: "624 Doby Avenue"
+    from_city: "orlando"
+    from_latitude: 28.534
+    from_longitude: -81.407
+    additional_passengers: 0
+    special_requests: none
+  -
+    pickup_offset: "-15 minutes"
+    from_address: "3337 Rogers Drive"
+    from_city: "orlando"
+    from_latitude: 28.531146
+    from_longitude: -81.419256
+    additional_passengers: 0
+    special_requests: none
+  -
+    pickup_offset: "15 minutes"
+    from_address: "1140 Martin L King Dr"
+    from_city: "orlando"
+    from_latitude: 28.5327758
+    from_longitude: -81.412722
+    additional_passengers: 0
+    special_requests: none
+  -
+    pickup_offset: "30 minutes"
+    from_address: "2001 West South Street"
+    from_city: "orlando"
+    from_latitude: 28.538499
+    from_longitude: -81.405609
+    additional_passengers: 0
+    special_requests: none

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -96,13 +96,13 @@ RSpec.describe Conversation, type: :model do
 
   describe 'event generation' do
     it 'sends new conversation event' do
-      expect_any_instance_of(RideZone).to receive(:event).with(:new_conversation, anything)
+      expect(RideZone).to receive(:event).with(anything, :new_conversation, anything)
       create :conversation
     end
 
     it 'sends conversation update event' do
       c = create :conversation
-      expect_any_instance_of(RideZone).to receive(:event).with(:conversation_changed, anything)
+      expect(RideZone).to receive(:event).with(c.ride_zone_id, :conversation_changed, anything)
       c.update_attribute(:status, :closed)
     end
   end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -76,14 +76,14 @@ RSpec.describe Message, type: :model do
     let!(:convo) { create :conversation_with_messages }
 
     it 'sends new message event' do
-      expect_any_instance_of(RideZone).to receive(:event).with(:new_message, anything)
-      expect_any_instance_of(RideZone).to receive(:event).with(:conversation_changed, anything)
+      expect(RideZone).to receive(:event).with(anything, :new_message, anything)
+      expect(RideZone).to receive(:event).with(anything, :conversation_changed, anything)
       create :message, conversation: convo
     end
 
     it 'sends message update event' do
       m = create :message, conversation: convo
-      expect_any_instance_of(RideZone).to receive(:event).with(:message_changed, anything)
+      expect(RideZone).to receive(:event).with(anything, :message_changed, anything)
       m.update_attribute(:sms_status, 'rejected')
     end
   end

--- a/spec/models/ride_spec.rb
+++ b/spec/models/ride_spec.rb
@@ -13,42 +13,42 @@ RSpec.describe Ride, type: :model do
     let!(:convo) { create :conversation_with_messages }
 
     it 'sends conversation event on new ride' do
-      expect_any_instance_of(RideZone).to receive(:event).with(:conversation_changed, anything)
+      expect(RideZone).to receive(:event).with(anything, :conversation_changed, anything)
       create :ride, conversation: convo, ride_zone: convo.ride_zone
     end
 
     it 'sends conversation update event but not driver' do
       r = create :ride, conversation: convo
-      expect_any_instance_of(RideZone).to receive(:event).with(:conversation_changed, anything)
-      expect_any_instance_of(RideZone).to_not receive(:event).with(:driver_changed, anything)
+      expect(RideZone).to receive(:event).with(anything, :conversation_changed, anything)
+      expect(RideZone).to_not receive(:event).with(anything, :driver_changed, anything)
       r.update_attribute(:pickup_at, Time.now)
     end
 
     it 'sends driver update event on status change' do
       r = create :ride, driver: driver, conversation: convo, ride_zone: convo.ride_zone
-      expect_any_instance_of(RideZone).to receive(:event).with(:conversation_changed, anything)
-      expect_any_instance_of(RideZone).to receive(:event).with(:driver_changed, anything, :driver)
+      expect(RideZone).to receive(:event).with(anything, :conversation_changed, anything)
+      expect(RideZone).to receive(:event).with(anything, :driver_changed, anything, :driver)
       r.update_attribute(:status, :picked_up)
     end
 
     it 'sends driver update event on driver clear' do
       r = create :ride, driver: driver, conversation: convo
-      expect_any_instance_of(RideZone).to receive(:event).with(:conversation_changed, anything)
-      expect_any_instance_of(RideZone).to receive(:event).with(:driver_changed, anything, :driver)
+      expect(RideZone).to receive(:event).with(anything, :conversation_changed, anything)
+      expect(RideZone).to receive(:event).with(anything, :driver_changed, anything, :driver)
       r.clear_driver
     end
 
     it 'sends driver update event on driver assignment' do
       r = create :ride, conversation: convo
-      expect_any_instance_of(RideZone).to receive(:event).with(:conversation_changed, anything)
-      expect_any_instance_of(RideZone).to receive(:event).with(:driver_changed, anything, :driver)
+      expect(RideZone).to receive(:event).with(anything, :conversation_changed, anything)
+      expect(RideZone).to receive(:event).with(anything, :driver_changed, anything, :driver)
       r.assign_driver(driver)
     end
 
     it 'sends driver update event on driver reassignment' do
       r = create :ride, conversation: convo, driver: driver
-      expect_any_instance_of(RideZone).to receive(:event).with(:conversation_changed, anything)
-      expect_any_instance_of(RideZone).to receive(:event).twice.with(:driver_changed, anything, :driver)
+      expect(RideZone).to receive(:event).with(anything, :conversation_changed, anything)
+      expect(RideZone).to receive(:event).twice.with(anything, :driver_changed, anything, :driver)
       r.reassign_driver(new_driver)
     end
   end

--- a/spec/models/simulation_spec.rb
+++ b/spec/models/simulation_spec.rb
@@ -9,16 +9,10 @@ ride_zone:
 drivers:
   -
     events:
-      -
-        at: 10
-        type: solo
+      - {at: 10, type: "move", lat: 34, lng: 122}
   -
     events:
-      -
-        at: 30
-        type: multi
-        repeat_count: 4
-        repeat_time: 10
+      - {at: 30, type: "move", lat: 34, lng: 122, repeat_count: 4, repeat_time: 10}
 driver
 
 RSpec.describe Simulation, :type => :model do
@@ -72,12 +66,12 @@ RSpec.describe Simulation, :type => :model do
     let(:sim) { Simulation.create_from_def(sim_def) }
 
     it 'creates drivers' do
-      sim.send(:prepare)
+      sim.send(:setup_data)
       expect(User.count).to eq(2)
     end
 
     it 'creates events' do
-      sim.send(:prepare)
+      sim.send(:setup_data)
       expect(sim.events.count).to eq(6)
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -174,18 +174,18 @@ RSpec.describe User, :type => :model do
     let(:rz) { create :ride_zone }
 
     it 'does not send event for new voter' do
-      expect_any_instance_of(RideZone).to_not receive(:event)
+      expect(RideZone).to_not receive(:event)
       create :voter_user, ride_zone: rz
     end
 
     it 'does not send event for updated voter' do
       u = create :voter_user, ride_zone: rz
-      expect_any_instance_of(RideZone).to_not receive(:event)
+      expect(RideZone).to_not receive(:event)
       u.update_attribute(:name, 'foobar')
     end
 
     it 'sends new driver event' do
-      expect_any_instance_of(RideZone).to receive(:event).with(:new_driver, anything, :driver)
+      expect(RideZone).to receive(:event).with(anything, :new_driver, anything, :driver)
       # cannot use factory because it doesn't create users the same way code
       # does with transient attributes
       User.create! name: 'foo', user_type: 'driver', ride_zone: rz, email: 'foo@example.com', phone_number: '+14155555555', phone_number_normalized: '+14155555555', password: '123456789'
@@ -193,7 +193,7 @@ RSpec.describe User, :type => :model do
 
     it 'sends driver update event on change' do
       d = create :driver_user, ride_zone: rz
-      expect_any_instance_of(RideZone).to receive(:event).with(:driver_changed, anything, :driver)
+      expect(RideZone).to receive(:event).with(rz.id, :driver_changed, anything, :driver)
       d.update_attribute(:name, 'foo bar')
     end
   end


### PR DESCRIPTION
Events to be processed at a particular second are now executed in parallel threads to get more throughput in the simulation. A variety of driver-intensive simulation files updating location at different rates exercise database writes as well as active cable event transmission/map updates to the dispatch page.

This does not exercise Twilio (completely skipped) or front-end requests hitting the web/API parts of the application. It is all backend direct model creation, updating, and event dispatching.
