### PR TITLE
Switch zip code in seed users to Florida so it will pass the state validation

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -82,7 +82,7 @@ if  Rails.env == "development"
       phone_number_normalized: '+12073328709',
       image_url: 'http://graph.facebook.com/v2.6/10155022838063242/picture',
       locale: 'en',
-      zip: '43606'
+      zip: '32601'
     }, {
       name: 'Doug Driver',
       available: false,
@@ -92,7 +92,7 @@ if  Rails.env == "development"
       phone_number_normalized: '+12073328709',
       image_url: 'http://graph.facebook.com/v2.6/10155022838063242/picture',
       locale: 'en',
-      zip: '43606'
+      zip: '32601'
     }
   ])
 


### PR DESCRIPTION
I'm new to this project.  When I tried to set up my environment, the database seed failed complaining about an invalid state (Ohio).  So, I updated the zip codes in the seed data to be in a valid state (Florida).

I don't have enough context to know if this is the preferred way to solve this; feel free to reject if not, or tell me to fix it another way.
