### PR TITLE
Add sign out link to header, fixes #472

### DIFF
--- a/webpack/driver/components/Header.js
+++ b/webpack/driver/components/Header.js
@@ -6,6 +6,9 @@ class Header extends React.Component {
         return (
             <nav className="container text-center p-y-sm">
 	            <a><img className="logo pull-left" src="/assets/dtv-logo-260w-eng-48cb2592520fc976c4cf3a9b47b4b23403b86e31972fea5dd4603a893cd8230e.png" /></a>
+	            <div className="pull-right nav-links">
+		            <a href="./users/sign_out" className="pull-right">Sign out</a>
+	            </div>
 			</nav>
         )
     }

--- a/webpack/driver/styles/drive-vote.css
+++ b/webpack/driver/styles/drive-vote.css
@@ -129,6 +129,10 @@ label {
     width: 50px;
 }
 
+.nav-links {
+    font-size: 12px;
+}
+
 .bottom-controls.fixed {
     position: fixed;
     bottom: 0;


### PR DESCRIPTION
Super simple, just added a 'sign out' link to the header of the app.
