### PR TITLE
Issue #548 create conversation even if twilio fails

### DIFF
--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -78,11 +78,14 @@ class Conversation < ApplicationRecord
   # create a new conversation initiated by staff
   # returns conversation if successful otherwise an error message
   def self.create_from_staff(ride_zone, user, body, timeout, attrs = {})
-    sms = send_staff_sms(ride_zone, user, body, timeout)
-    return sms if sms.is_a?(String)
     c = Conversation.create({ride_zone: ride_zone, user: user, from_phone: ride_zone.phone_number_normalized,
                             to_phone: user.phone_number_normalized, status: :in_progress}.merge(attrs))
-    msg = Message.create_from_staff(c, sms)
+    sms = send_staff_sms(ride_zone, user, body, timeout)
+    if sms.is_a?(String)
+      # create dummy message so we know what we intended to send
+      sms = OpenStruct.new(sid: 'n/a', status: 'failed', body: "(Failed to send) #{body}")
+    end
+    Message.create_from_staff(c, sms)
     c
   end
 

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -123,10 +123,12 @@ RSpec.describe Conversation, type: :model do
       Conversation.create_from_staff(rz, user, body, 5)
     end
 
-    it 'handles twilio error' do
+    it 'handles twilio error and creates conversation' do
       expect(TwilioService).to receive(:send_message).and_return(OpenStruct.new(error_code: 123))
-      expect(Conversation.create_from_staff(rz, user, body, 5) =~ /Communication error/).to be_truthy
-      expect(Conversation.count).to eq(0)
+      expect(Conversation.create_from_staff(rz, user, body, 5).class).to eq(Conversation)
+      msg = Conversation.last.messages.last
+      expect(msg.sent_by).to eq('Staff')
+      expect(msg.body =~ /#{body}/).to be_truthy
     end
 
     it 'creates a conversation and message' do


### PR DESCRIPTION
If Twilio is having a problem or we accidentally use a poorly configured ridezone we don't want a newly created ride to disappear. So always create a conversation and put in an indicator that the send failed.
