### PR TITLE
Issue #615 bad data in dev stopped confirmation sms

### DIFF
--- a/app/models/ride.rb
+++ b/app/models/ride.rb
@@ -186,7 +186,7 @@ class Ride < ApplicationRecord
   def self.confirm_scheduled_rides
     count, errors = 0, 0
     Ride.where(status: :scheduled).where('pickup_at < ?', SWITCH_TO_WAITING_ASSIGNMENT.minutes.from_now).each do |ride|
-      if ride.conversation && !ride.ride_zone.bot_disabled
+      if ride.conversation && ride.ride_zone && !ride.ride_zone.bot_disabled
         begin
           ride.conversation.attempt_confirmation
           count += 1

--- a/spec/models/ride_spec.rb
+++ b/spec/models/ride_spec.rb
@@ -305,6 +305,16 @@ RSpec.describe Ride, type: :model do
       expect(Conversation).to_not receive(:send_staff_sms)
       Ride.confirm_scheduled_rides
     end
+
+    it 'does not attempt if no ride zone' do
+      stub_const('Ride::SWITCH_TO_WAITING_ASSIGNMENT', 10)
+      c1 = create :complete_conversation, pickup_at: 20.minutes.from_now
+      r = Ride.create_from_conversation(c1)
+      r.ride_zone = nil; r.save
+      stub_const('Ride::SWITCH_TO_WAITING_ASSIGNMENT', 30)
+      expect(Conversation).to_not receive(:send_staff_sms)
+      Ride.confirm_scheduled_rides
+    end
   end
 
   it 'produces safe api text' do


### PR DESCRIPTION
We have rides in the database that point to deleted ride zones in the dev instance. That created a null pointer reference in the logic sending out confirmation SMS's
