### PR TITLE
Issue #689 help needed overrides ride status in dispatch view

### DIFF
--- a/app/assets/javascripts/dispatch.js.erb
+++ b/app/assets/javascripts/dispatch.js.erb
@@ -197,6 +197,10 @@ DispatchController.prototype = {
         last_msg_time = new Date(c.last_message_time * 1000),
         now = Date.now(),
         status = c.status;
+
+    if (status == 'help_needed')
+      return 'help_needed';
+
     if (ride !== undefined && ride !== null) {
       switch (ride.status) {
         case 'complete':
@@ -215,16 +219,18 @@ DispatchController.prototype = {
           if (now > desired_time - this.OVERDUE_ASSIGNMENT)
             return 'assignment_overdue';
           return 'waiting_assignment';
+        case 'waiting_acceptance':
+          return 'scheduled';
+        case 'scheduled':
+          if (now > desired_time)
+            return 'assignment_overdue';
+          return 'scheduled';
         default:
           return ride.status;
       }
     }
-    switch(status) {
-      case 'help_needed':
-        return 'help_needed';
-      case 'closed':
+    if (status == 'closed')
         return 'complete';
-    }
     if (c.message_count == 0 || now - last_msg_time > 20*60*1000)
       return 'help_needed';
     return 'messaging';


### PR DESCRIPTION
Thanks @bradyk for finding this one. When a conversation goes into help needed that status should be looked at first before ride status so it gets dispatcher's attention.

Also saw that the new ride status waiting_acceptance was not handled. From dispatch point of view, this should just be 'scheduled' (no need for different text or icons).

Also, in case there are bugs in the worker moving scheduled jobs to waiting_acceptance, mark scheduled jobs whose pickup has passed overdue so they get attention.