### PR TITLE
Issue #697 fix before actions to handle conversation endpoints

### DIFF
--- a/app/controllers/dispatch_controller.rb
+++ b/app/controllers/dispatch_controller.rb
@@ -3,6 +3,7 @@ class DispatchController < ApplicationController
   include AccessMethods
 
   before_action :set_ride_zone, except: [:messages, :ride_pane]
+  before_action :set_conversation, only: [:messages, :ride_pane]
   before_action :require_zone_dispatch
   before_action :get_driver_count, except: [:messages, :ride_pane]
 
@@ -11,12 +12,10 @@ class DispatchController < ApplicationController
   end
 
   def messages
-    @conversation = Conversation.find(params[:id])
     render partial: 'messages'
   end
 
   def ride_pane
-    @conversation = Conversation.find(params[:id])
     ride = @conversation.ride
     @zone_driver_count = @conversation.ride_zone.drivers.count
     @available_drivers = @conversation.ride_zone.available_drivers
@@ -79,4 +78,8 @@ class DispatchController < ApplicationController
     @driver_count = @ride_zone.drivers.count(:all)
   end
 
+  def set_conversation
+    @conversation = Conversation.find(params[:id])
+    @ride_zone = @conversation.ride_zone
+  end
 end

--- a/spec/controllers/dispatch_controller_spec.rb
+++ b/spec/controllers/dispatch_controller_spec.rb
@@ -45,6 +45,24 @@ RSpec.describe DispatchController, :type => :controller do
         expect(assigns(:conversation)).to eq(convo)
       end
     end
+
+    context 'as zone admin' do
+      login_rz_admin
+
+      it 'assigns the requested conversation as @conversation' do
+        get :messages, params: {id: convo.to_param}
+        expect(assigns(:conversation)).to eq(convo)
+      end
+    end
+
+    context 'as dispatcher' do
+      login_dispatcher
+
+      it 'assigns the requested conversation as @conversation' do
+        get :messages, params: {id: convo.to_param}
+        expect(assigns(:conversation)).to eq(convo)
+      end
+    end
   end
 
   describe 'GET #ride_pane' do
@@ -92,6 +110,24 @@ RSpec.describe DispatchController, :type => :controller do
           expect(assigns(:available_drivers_with_distance)[1][0].id).to eq(d3.id)
           expect(assigns(:available_drivers_with_distance)[2][0].id).to eq(d1.id)
         end
+      end
+    end
+
+    context 'as zone admin' do
+      login_rz_admin
+
+      it 'assigns the requested conversation as @conversation' do
+        get :ride_pane, params: {id: convo.to_param}
+        expect(assigns(:conversation)).to eq(convo)
+      end
+    end
+
+    context 'as dispatcher' do
+      login_dispatcher
+
+      it 'assigns the requested conversation as @conversation' do
+        get :ride_pane, params: {id: convo.to_param}
+        expect(assigns(:conversation)).to eq(convo)
       end
     end
   end


### PR DESCRIPTION
Ride zone was not being set because set_ride_zone wasn't called, so require_zone_dispatch failed