### PR TITLE
Issue #591 modal errors when sending messages

### DIFF
--- a/app/assets/javascripts/dispatch.js.erb
+++ b/app/assets/javascripts/dispatch.js.erb
@@ -82,6 +82,7 @@ DispatchController.prototype = {
       if (!sameConvo) {
         $('#msg-input').text('');
         $('#msg-input').prop('disabled',false);
+        $('#msg-error-display').html('')
       }
     });
   },
@@ -462,7 +463,21 @@ DispatchController.prototype = {
     var args = {'message' : {'body': $('#msg-input').text()}};
     var url = '/api/1/conversations/' + this._activeConversationId + '/messages';
 
-    $.ajax(url, {type: 'POST', dataType: 'json', data: args, process_data: false, content_type: 'application/json'});
+    $.ajax(url, {
+      type: 'POST',
+      dataType: 'json',
+      data: args,
+      process_data: false,
+      content_type: 'application/json',
+      success: function(data, textStatus, jqXHR) {
+        $('#msg-error-display').html('')
+      },
+      error: function( jqXHR, textStatus, errorThrown ) {
+        $('#msg-submit').text('Send...').prop('disabled',false);
+        $('#msg-input').prop('disabled',false);
+        $('#msg-error-display').html('Your message failed to send:<br>' + jqXHR.responseJSON['error'])
+      }
+    });
   },
 
   // Called for new conversation event or changed

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -134,13 +134,13 @@ class Conversation < ApplicationRecord
       logger.error "TWILIO ERROR #{e.message} User id #{user.id} Message #{body}"
       return "Twilio error #{e.message}"
     end
-    logger.info "TWILIO sent staff sms to #{user.phone_number} from #{ride_zone.phone_number_normalized}: #{body} code: #{sms.error_code} status: #{sms.status}"
+    info = "user_id: #{user.id} to: #{user.phone_number} from: #{ride_zone.phone_number_normalized}: '#{body}'"
+    logger.info "TWILIO sent staff sms #{info} code: #{sms.error_code} status: #{sms.status}"
     if sms.error_code
-      logger.error "TWILIO ERROR #{sms.error_code} User id #{user.id} Message #{body}"
+      logger.error "TWILIO ERROR #{sms.error_code} #{info}"
       return "Communication error #{sms.error_code}"
     elsif sms.status.to_s != 'delivered'
-      logger.error "TWILIO ERROR Timeout User id #{user.id} Message #{body}"
-      return 'Timeout in delivery'
+      logger.error "TWILIO note timeout #{info}"
     end
     sms
   end

--- a/app/services/twilio_service.rb
+++ b/app/services/twilio_service.rb
@@ -33,16 +33,16 @@ class TwilioService
 
   # sends an SMS message with specified data and waits up to timeout seconds
   # for the status to become 'delivered' or have a non-nil error_code
-  # returns the Twilio message object
+  # returns the Twilio message object unless there is a hard error from twilio
+  # that raises
   def self.send_message(args, timeout)
     raise 'Do not call Twilio in test' if Rails.env.test?
-    sms = nil
 
-    Timeout::timeout(timeout) do
-      sms = twilio_client.messages.create(args)
-      while sms.error_code.nil? && sms.status.to_s != 'delivered'
+    end_time = timeout.seconds.from_now
+    sms = twilio_client.messages.create(args)
+    while sms.error_code.nil? && sms.status.to_s != 'delivered' && Time.now <= end_time
+        sleep(0.5)
         sms.refresh
-      end
     end
     sms
   end

--- a/app/views/dispatch/_modal.html.haml
+++ b/app/views/dispatch/_modal.html.haml
@@ -23,3 +23,7 @@
               .msg-reply
                 #msg-input{ contenteditable: true}
                 = button_tag 'Send', id: 'msg-submit', class: 'btn btn-send btn-primary btn-xs pull-right'
+          %tr
+            %td
+            %td
+              #msg-error-display


### PR DESCRIPTION
Our "timeout" was actually not twilio not responding to us - it was waiting 5 seconds for the SMS to get marked 'delivered', which of course can take a fair amount of time over the cell network. So we no longer treat that as an error and trust twilio will deliver it for us.

Also handle errors in the modal by displaying the error message and re-enabling the Send button.