### PR TITLE
Issue #770 don't SMS voter until driver accepts the ride

### DIFF
--- a/app/models/ride.rb
+++ b/app/models/ride.rb
@@ -219,7 +219,10 @@ class Ride < ApplicationRecord
   end
 
   def notify_voter_about_driver
-    if (self.status_changed? && self.status == 'driver_assigned') || self.driver_id_changed?
+    # notify voter IF
+    # ride became driver_assigned or is assigned and driver id changed or driver was cleared when it was assigned
+    if ((self.status_changed? || self.driver_id_changed?) && self.status == 'driver_assigned') ||
+       (self.driver_id_changed? && self.driver.nil? && self.status_was == 'driver_assigned')
       self.conversation.notify_voter_of_assignment(self.driver) if self.conversation
     end
   end

--- a/spec/models/ride_spec.rb
+++ b/spec/models/ride_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Ride, type: :model do
 
     it 'sends driver update event on driver clear' do
       allow_any_instance_of(Conversation).to receive(:notify_voter_of_assignment)
-      r = create :ride, driver: driver, conversation: convo
+      r = create :ride, driver: driver, conversation: convo, status: :driver_assigned
       expect(RideZone).to receive(:event).with(anything, :conversation_changed, anything)
       expect(RideZone).to receive(:event).with(anything, :driver_changed, anything, :driver)
       expect_any_instance_of(Conversation).to receive(:notify_voter_of_assignment).with(nil)
@@ -129,6 +129,21 @@ RSpec.describe Ride, type: :model do
       ride = Ride.create_from_conversation(convo)
       expect_any_instance_of(Conversation).to receive(:notify_voter_of_assignment)
       ride.assign_driver(driver, false, false)
+    end
+
+    it 'does not send voter a text on driver waiting_acceptance' do
+      convo = create :complete_conversation
+      ride = Ride.create_from_conversation(convo)
+      expect_any_instance_of(Conversation).to_not receive(:notify_voter_of_assignment)
+      ride.assign_driver(driver, false, true)
+    end
+
+    it 'does not send voter a text on driver canceling waiting_acceptance' do
+      convo = create :complete_conversation
+      ride = Ride.create_from_conversation(convo)
+      ride.assign_driver(driver, false, true)
+      expect_any_instance_of(Conversation).to_not receive(:notify_voter_of_assignment)
+      ride.clear_driver(driver)
     end
 
     it 'does not assign driver if already has one' do


### PR DESCRIPTION
Logic needed to be made more precise after introducing the waiting_acceptance state for a ride.

SMS should only be sent notifying voter of a driver if state is driver_assigned (not when waiting_acceptance)

or when driver is cleared from the ride and state was driver_assigned