### PR TITLE
Issue #781 redirect to 404 for standard not found errors

### DIFF
--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -2,6 +2,10 @@ module Api
   class ApplicationController < ActionController::Base
     protect_from_forgery with: :exception, prepend: true
 
+    rescue_from(ActionController::RoutingError, ActionController::UnknownController, ActiveRecord::RecordNotFound) do
+      render json: {error: 'Not found'}, status: 404
+    end
+
   end
 end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,10 @@ class ApplicationController < ActionController::Base
   # https://github.com/plataformatec/devise/pull/4033/files
   protect_from_forgery with: :exception, prepend: true
 
+  rescue_from(ActionController::RoutingError, ActionController::UnknownController, ActiveRecord::RecordNotFound) do
+    redirect_to '/404.html'
+  end
+
   before_action :set_locale
   before_action :configure_permitted_parameters, if: :devise_controller?
 

--- a/app/controllers/concerns/ride_zone_params.rb
+++ b/app/controllers/concerns/ride_zone_params.rb
@@ -6,6 +6,7 @@ module RideZoneParams
   # Use callbacks to share common setup or constraints between actions.
   def set_ride_zone(param = :id)
     @ride_zone = RideZone.find_by_id(params[param]) || RideZone.find_by_slug(params[param])
+    raise ActiveRecord::RecordNotFound.new unless @ride_zone
   end
 
   # Only allow a trusted parameter "white list" through.


### PR DESCRIPTION
Unfortunately wasn't able to get rid of the FATAL stderr logging of routing errors.

Also, found that ride zone find by id or slug was not raising an error if not found. Changed to match behavior of all other "set_xxx" routines that do a straight Class.find(id) which will raise error if the record is not found.