### PR TITLE
Use our own image for circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,54 +1,24 @@
-# This configuration was automatically generated from a CircleCI 1.0 config.
-# It should include any build commands you had along with commands that CircleCI
-# inferred from your project structure. We strongly recommend you read all the
-# comments in this file to understand the structure of CircleCI 2.0, as the idiom
-# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
-# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
-# configuration as a reference rather than using it in production, though in most
-# cases it should duplicate the execution of your original 1.0 config.
 version: 2
 jobs:
   build:
     working_directory: ~/john/drive.vote
     parallelism: 1
     shell: /bin/bash --login
-    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
-    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
+    
     environment:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
-    # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
-    # In CircleCI 2.0 you can now specify your own image, or use one of our pre-configured images.
-    # The following configuration line tells CircleCI to use the specified docker image as the runtime environment for you job.
-    # We have selected a pre-built image that mirrors the build environment we use on
-    # the 1.0 platform, but we recommend you choose an image more tailored to the needs
-    # of each job. For more information on choosing an image (or alternatively using a
-    # VM instead of a container) see https://circleci.com/docs/2.0/executor-types/
-    # To see the list of pre-built images that CircleCI provides for most common languages see
-    # https://circleci.com/docs/2.0/circleci-images/
+      
     docker:
-    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
-      command: /sbin/init
+    - image: johnmcgrath/drivevote_web
+    - image: postgres:10.5-alpine
+    
     steps:
-    # Machine Setup
-    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
-    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
+      
     - checkout
-    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
-    # In many cases you can simplify this from what is generated here.
-    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+    
     - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
-    # This is based on your 1.0 configuration file or project settings
-    - run:
-        working_directory: ~/john/drive.vote
-        command: nvm install 4.5.0 && nvm alias default 4.5.0
-    # This is based on your 1.0 configuration file or project settings
-    - run:
-        working_directory: ~/john/drive.vote
-        command: npm install -g npm@3.8.9
-    # Dependencies
-    #   This would typically go in either a build or a build-and-test job when using workflows
-    # Restore the dependency cache
+    
     - restore_cache:
         keys:
         # This branch if available
@@ -57,54 +27,36 @@ jobs:
         - v1-dep-master-
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
-    # The following line was run implicitly in your 1.0 builds based on what CircleCI inferred about the structure of your project. In 2.0 you need to be explicit about which commands should be run. In some cases you can discard inferred commands if they are not relevant to your project.
-    - run: if [ -z "${NODE_ENV:-}" ]; then export NODE_ENV=test; fi
-    - run: export PATH="~/john/drive.vote/node_modules/.bin:$PATH"
-    - run: npm install
+          
+    # Uncomment if at some point we need npm installed to run tests
+    # - run: if [ -z "${NODE_ENV:-}" ]; then export NODE_ENV=test; fi
+    # - run: export PATH="~/john/drive.vote/node_modules/.bin:$PATH"
+    # - run: npm install
+    
     - run: echo -e "export RAILS_ENV=test\nexport RACK_ENV=test" >> $BASH_ENV
+    
     - run: 'bundle check --path=vendor/bundle || bundle install --path=vendor/bundle
         --jobs=4 --retry=3 '
-    # You can remove the conditional and simply install the requirements file you use
-    - run: if [ -e requirements.txt ]; then pip install -r requirements.txt; else pip install -r requirements.pip; fi
-    # Save dependency cache
+        
     - save_cache:
         key: v1-dep-{{ .Branch }}-{{ epoch }}
         paths:
-        # This is a broad list of cache paths to include many possible development environments
-        # You can probably delete some of these entries
         - vendor/bundle
-        - ~/virtualenvs
-        - ~/.m2
-        - ~/.ivy2
         - ~/.bundle
-        - ~/.go_workspace
-        - ~/.gradle
-        - ~/.cache/bower
         - ./node_modules
-    # The following line was run implicitly in your 1.0 builds based on what CircleCI inferred about the structure of your project. In 2.0 you need to be explicit about which commands should be run. In some cases you can discard inferred commands if they are not relevant to your project.
-    - run: |-
-        mkdir -p config && echo 'test:
-          database: circle_ruby_test
-          adapter: postgresql
-          encoding: unicode
-          pool: 40
-          timeout: 5000
-          username: ubuntu
-          host: localhost
-        ' > config/database.yml
+
     - run:
         command: bundle exec rake db:create db:schema:load --trace
         environment:
           RAILS_ENV: test
           RACK_ENV: test
-    # Test
-    #   This would typically be a build job when using workflows, possibly combined with build
-    # The following line was run implicitly in your 1.0 builds based on what CircleCI inferred about the structure of your project. In 2.0 you need to be explicit about which commands should be run. In some cases you can discard inferred commands if they are not relevant to your project.
+          
     - run:
         command: bundle exec rspec --color --require spec_helper --format progress spec
         environment:
           RAILS_ENV: test
           RACK_ENV: test
+          
     # Teardown
     #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
     # Save test results


### PR DESCRIPTION
Tests started failing due to not being able to find bundler, was hard to debug because our CircleCI config file had been recently auto-generated when we switched from 1.0 to 2.0. Since we're now dockerized I uploaded our image to Docker Hub, and used it as the basis for running CircleCI, rather than one of their generic images.

Config is now easier to read, better mirrors our dev environment, and will better mirror prod as well, if we start deploying via Docker, which would be a Good Idea.