### PR TITLE
✅ add more specs for POST /admin/rides

### DIFF
--- a/app/controllers/admin/rides_controller.rb
+++ b/app/controllers/admin/rides_controller.rb
@@ -38,7 +38,7 @@ class Admin::RidesController < Admin::AdminApplicationController
 
     if @ride.save
       @ride.conversation = Conversation.find(params[:conversation_id]) if params[:conversation_id]
-      redirect_to [:admin, @ride], notice: 'Ride was successfully created.'
+      redirect_to [:admin, @ride], notice: 'Ride was successfully created.', status: :see_other
     else
       render :new
     end

--- a/spec/controllers/admin/rides_controller_spec.rb
+++ b/spec/controllers/admin/rides_controller_spec.rb
@@ -5,8 +5,13 @@ RSpec.describe Admin::RidesController, type: :controller do
   # This should return the minimal set of attributes required to create a valid
   # Ride. As you add validations to Ride, be sure to
   # adjust the attributes here as well.
+  let(:voter) { create :voter }
+
   let(:valid_attributes) {
-    {voter_id: 1, name: 'foo', description: 'bar'}
+    {
+      name: 'A ride',
+      voter_id: voter.id,
+    }
   }
 
   let(:invalid_attributes) {
@@ -80,10 +85,22 @@ RSpec.describe Admin::RidesController, type: :controller do
     end
   end
 
-  describe "GET #create" do
+  describe "POST #create" do
     it "redirects if not logged in" do
-      post :create, params: {id: ride.to_param}
+      post :create, params: {ride: valid_attributes}
+      expect(Ride.all.length).to be(0)
       expect(response).to redirect_to('/404.html')
+    end
+
+    context "as admin" do
+      login_admin
+
+      it "accepts JSON with a single ride's info" do
+        post :create, params: {ride: valid_attributes}
+        expect(response).to have_http_status(:see_other)
+        expect(response.headers['Location']).to match(/\/admin\/rides\/\d+/)
+        expect(assigns(:ride)).to be_a(Ride)
+      end
     end
   end
 


### PR DESCRIPTION
As prep for #899, this fills out the specs for `POST /admin/rides`. It also changes the redirect response code to [303](https://httpstatuses.com/303), which,

> is primarily used to allow the output of a POST action to redirect the user agent to a selected resource, since doing so provides the information corresponding to the POST response in a form that can be separately identified, bookmarked, and cached, independent of the original request.