### PR TITLE
Remove city-state gem

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
       
     docker:
-    - image: johnmcgrath/drivevote_web
+    - image: johnmcgrath/drivevote_web:add_git
     - image: postgres:10.5-alpine
     
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,15 @@ FROM ruby:2.5.1-alpine3.7
 
 RUN apk update
 RUN apk add \
+  bash \
   build-base \
+  git \
+  nodejs \
   python3 \
   postgresql-dev \
   postgresql-client \
-  bash \
-  nodejs \
-  yarn \
   tzdata \
+  yarn \
   && rm -rf /var/cache/apk/*
 
 # RUN gem install bundler

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source 'https://rubygems.org'
 ruby '2.5.1'
 
 gem 'bootsnap', '>= 1.1.0', require: false
-gem 'city-state', :git => 'https://github.com/john/city-state.git'
 gem 'chronic', '0.10.2'
 gem 'coffee-rails' # shouldnt be necessary, not using, but one line in /spec/requests/dispatcher_spec.rb fails without it, super weirdly
 gem 'devise', '4.4.3'

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 ruby '2.5.1'
 
 gem 'bootsnap', '>= 1.1.0', require: false
-gem 'city-state', '0.0.13'
+gem 'city-state', :git => 'https://github.com/john/city-state.git'
 gem 'chronic', '0.10.2'
 gem 'coffee-rails' # shouldnt be necessary, not using, but one line in /spec/requests/dispatcher_spec.rb fails without it, super weirdly
 gem 'devise', '4.4.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/john/city-state.git
-  revision: 24a1c99e435ea2f0bc80ae0d4edb27d641ac0948
-  specs:
-    city-state (0.0.13)
-      rubyzip (~> 1.2.2)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -367,7 +360,6 @@ DEPENDENCIES
   bundler-audit
   byebug
   chronic (= 0.10.2)
-  city-state!
   coffee-rails
   devise (= 4.4.3)
   dotenv-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/john/city-state.git
+  revision: 24a1c99e435ea2f0bc80ae0d4edb27d641ac0948
+  specs:
+    city-state (0.0.13)
+      rubyzip (~> 1.2.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -57,8 +64,6 @@ GEM
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     chronic (0.10.2)
-    city-state (0.0.13)
-      rubyzip (~> 1.1)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -261,7 +266,7 @@ GEM
     ruby_dep (1.5.0)
     ruby_parser (3.11.0)
       sexp_processor (~> 4.9)
-    rubyzip (1.2.1)
+    rubyzip (1.2.2)
     safe_yaml (1.0.4)
     sass (3.5.7)
       sass-listen (~> 4.0.0)
@@ -362,7 +367,7 @@ DEPENDENCIES
   bundler-audit
   byebug
   chronic (= 0.10.2)
-  city-state (= 0.0.13)
+  city-state!
   coffee-rails
   devise (= 4.4.3)
   dotenv-rails
@@ -417,4 +422,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.3
+   1.16.4


### PR DESCRIPTION
*UPDATE: After looking carefully, I'm almost certain we're not using this gem, so updated the PR to remove it entirely. Specs pass.

__

The city-state gem we're using relies on rubyzip 1.1, which has a security vulnerability. The gem isn't being maintained, so I forked it and upgraded rubyzip to the most recent version, 1.2.2.

Because the Gemfile now refers to a git repo rather than just rubygems, it also necessitated updating the Dockerfile to include git, so that gems can be built correctly when creating a new container image.

Note that once this is merged everyone will have to update their local Docker images, since the Dockerfile changed.