### PR TITLE
development.rb: Add logging to STDOUT

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -44,6 +44,10 @@ Rails.application.configure do
 
   config.assets.quiet = true
 
+  logger = ActiveSupport::Logger.new(STDOUT)
+  logger.formatter = config.log_formatter
+  config.logger = ActiveSupport::TaggedLogging.new(logger)
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 


### PR DESCRIPTION
This revision addresses an issue in which the development server, when run via `docker-compose up` at least (but probably in other invocations), had no logged output.

Test Plan: Re-ran server and saw general log output from request handling (HTTP level logging, timing, etc), as well as log statements emitted from within a controller. 

Sample output from a now-logged request:
```
web_1    | 22:41:19 web.1     | Started GET "/admin/ride_zones/berkeley" for 172.18.0.1 at 2018-09-07 22:41:19 +0000
web_1    | 22:41:19 web.1     | Cannot render console from 172.18.0.1! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
web_1    | 22:41:19 web.1     |    (0.8ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
web_1    | 22:41:19 web.1     | Logging (testing of logger from within a controller)
web_1    | 22:41:19 web.1     | Processing by Admin::RideZonesController#show as HTML
web_1    | 22:41:19 web.1     |   Parameters: {"id"=>"berkeley"}
web_1    | 22:41:19 web.1     |   RideZone Load (0.6ms)  SELECT  "ride_zones".* FROM "ride_zones" WHERE "ride_zones"."id" = $1 LIMIT $2  [["id", 0], ["LIMIT", 1]]
web_1    | 22:41:19 web.1     |   RideZone Load (0.5ms)  SELECT  "ride_zones".* FROM "ride_zones" WHERE "ride_zones"."slug" = $1 LIMIT $2  [["slug", "berkeley"], ["LIMIT", 1]]
web_1    | 22:41:19 web.1     |   User Load (0.7ms)  SELECT  "users".* FROM "users" WHERE "users"."id" = $1 ORDER BY "users"."id" ASC LIMIT $2  [["id", 1], ["LIMIT", 1]]
web_1    | 22:41:19 web.1     |   Role Load (1.3ms)  SELECT "roles".* FROM "roles" INNER JOIN "users_roles" ON "roles"."id" = "users_roles"."role_id" WHERE "users_roles"."user_id" = $1 AND (((roles.name = 'admin') AND (roles.resource_type IS NULL) AND (roles.resource_id IS NULL)))  [["user_id", 1]]
web_1    | 22:41:19 web.1     |   Role Load (0.6ms)  SELECT  "roles".* FROM "roles" WHERE "roles"."resource_type" = $1 AND "roles"."resource_id" = $2 AND "roles"."name" = $3 ORDER BY "roles"."id" ASC LIMIT $4  [["resource_type", "RideZone"], ["resource_id", 1], ["name", "dispatcher"], ["LIMIT", 1]]
web_1    | 22:41:19 web.1     |   Role Load (0.5ms)  SELECT  "roles".* FROM "roles" WHERE "roles"."resource_type" = $1 AND "roles"."resource_id" = $2 AND "roles"."name" = $3 ORDER BY "roles"."id" ASC LIMIT $4  [["resource_type", "RideZone"], ["resource_id", 1], ["name", "driver"], ["LIMIT", 1]]
web_1    | 22:41:19 web.1     |   Rendering admin/ride_zones/show.html.haml within layouts/application
web_1    | 22:41:19 web.1     |   CACHE Role Load (0.0ms)  SELECT "roles".* FROM "roles" INNER JOIN "users_roles" ON "roles"."id" = "users_roles"."role_id" WHERE "users_roles"."user_id" = $1 AND (((roles.name = 'admin') AND (roles.resource_type IS NULL) AND (roles.resource_id IS NULL)))  [["user_id", 1]]
web_1    | 22:41:19 web.1     |   Rendered admin/_nav.html.haml (8.1ms)
web_1    | 22:41:19 web.1     |   Role Exists (0.8ms)  SELECT  1 AS one FROM "roles" INNER JOIN "users_roles" ON "roles"."id" = "users_roles"."role_id" WHERE "users_roles"."user_id" = $1 AND "roles"."name" = $2 AND "roles"."resource_type" = $3 AND "roles"."resource_id" = $4 LIMIT $5  [["user_id", 1], ["name", "admin"], ["resource_type", "RideZone"], ["resource_id", 1], ["LIMIT", 1]]
web_1    | 22:41:19 web.1     |   Rendered admin/ride_zones/show.html.haml within layouts/application (40.8ms)
web_1    | 22:41:20 web.1     |   CACHE Role Load (0.0ms)  SELECT "roles".* FROM "roles" INNER JOIN "users_roles" ON "roles"."id" = "users_roles"."role_id" WHERE "users_roles"."user_id" = $1 AND (((roles.name = 'admin') AND (roles.resource_type IS NULL) AND (roles.resource_id IS NULL)))  [["user_id", 1]]
web_1    | 22:41:20 web.1     |   Rendered application/_nav.html.haml (30.7ms)
web_1    | 22:41:21 web.1     |   Rendered application/_footer.html.haml (17.1ms)
web_1    | 22:41:21 web.1     | Completed 200 OK in 1303ms (Views: 1107.9ms | ActiveRecord: 15.8ms)
web_1    | 22:41:21 web.1     | 
web_1    | 22:41:21 web.1     | 
```