### PR TITLE
dispatchers can block, admin fixes

### DIFF
--- a/app/assets/javascripts/dispatch.js.erb
+++ b/app/assets/javascripts/dispatch.js.erb
@@ -278,9 +278,15 @@ DispatchController.prototype = {
     } else {
       cells = cells + c.from_phone
     }
-
+    
+    if ( typeof c.blacklisted_phone_number === 'undefined') {
+      var status_text = this._statusStrings[status]
+    } else {
+      var status_text = '<i>BLOCKED #</i>'
+    }
+    
     cells = cells + '</b></div>' + msg.truncate(100) + '</td>' +
-      '<td class="conv-status"><span class="conv-statdisp conv-statdisp-'+status+'">' + this._statusStrings[status] + '</span></td>';
+      '<td class="conv-status"><span class="conv-statdisp conv-statdisp-'+status+'">' + status_text + '</span></td>';
 
     if (status == 'complete' || status == 'driving') {
       cells = cells + '<td class="conv-time"></td>';

--- a/app/assets/stylesheets/drive.vote.css.scss
+++ b/app/assets/stylesheets/drive.vote.css.scss
@@ -23,6 +23,10 @@ footer {
   height: 45px;
   margin-top: 80px;
   margin: auto;
+  
+  .privacy {
+    margin: 5px 150px 0 0;
+  }
 
   .center {
     margin: 0 auto;
@@ -31,12 +35,6 @@ footer {
       display: inline;
       text-align: center;
 
-      .fb {
-        padding: 5px 5px 10px 10px;
-      }
-      .tw {
-        padding: 10px 10px 10px 0;
-      }
       .email {
         font-size: 14px;
         padding: 9px 0 0 5px;
@@ -287,7 +285,7 @@ h3.dispatch { margin: 0 0 0 10px; }
   }
 }
 
-.archive-convo {
+.archive-convo .block-convo .unblock-convo {
   margin-top: 10px;
 }
 
@@ -410,6 +408,7 @@ h3.dispatch { margin: 0 0 0 10px; }
 
 
 @media(max-width:992px) {
+  
   .btn-home {
     width: 220px;
     font-size: 16px;
@@ -421,6 +420,13 @@ h3.dispatch { margin: 0 0 0 10px; }
   }
   .btn-rgt {
     margin-left: 10px;
+  }
+}
+
+@media(max-width:768px) {
+  
+  .privacy {
+    display: none;
   }
 }
 

--- a/app/controllers/admin/admin_application_controller.rb
+++ b/app/controllers/admin/admin_application_controller.rb
@@ -13,6 +13,7 @@ class Admin::AdminApplicationController < ApplicationController
 
   def require_admin_privileges
     unless user_signed_in? && (current_user.has_role?(:admin) || (@ride_zone && current_user.has_role?(:admin, @ride_zone)))
+      # render file: "#{Rails.root}/public/404", status: :not_found
       redirect_to '/404.html'
     end
   end

--- a/app/controllers/admin/conversations_controller.rb
+++ b/app/controllers/admin/conversations_controller.rb
@@ -1,5 +1,6 @@
 class Admin::ConversationsController < Admin::AdminApplicationController
 
+  skip_before_action :require_admin_privileges, only: [:blacklist_voter_phone, :unblacklist_voter_phone] 
   before_action :set_conversation, only: [:show, :messages, :ride_pane, :update_attribute, :close, :blacklist_voter_phone, :unblacklist_voter_phone]
 
   # GET /admin/conversations

--- a/app/controllers/admin/ride_zones_controller.rb
+++ b/app/controllers/admin/ride_zones_controller.rb
@@ -36,6 +36,7 @@ class Admin::RideZonesController < Admin::AdminApplicationController
   def setup_edit
     @zone_dispatchers = @ride_zone.dispatchers
     @zone_drivers = @ride_zone.drivers
+    @zone_unassigned_drivers = @ride_zone.unassigned_drivers
     @zone_admins = @ride_zone.admins
 
     # TODO: scope to nearby when adding proximity

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception, prepend: true
 
   rescue_from(ActionController::RoutingError, ActiveRecord::RecordNotFound) do
+    # render file: "#{Rails.root}/public/404", status: :not_found
     redirect_to '/404.html'
   end
 

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -33,15 +33,15 @@ class Conversation < ApplicationRecord
     info_complete: 1000,
     requested_confirmation: 1100,
   }
-
+  
   def api_json(include_messages = false)
     fields = [:id, :user_id, :pickup_at, :status, :lifecycle, :from_phone,
-              :from_latitude, :from_longitude, :to_latitude, :to_longitude, :additional_passengers]
+              :from_latitude, :from_longitude, :to_latitude, :to_longitude, :additional_passengers, :blacklisted_phone_number]
     j = self.as_json(only: fields, methods: [:message_count])
     if include_messages
       j['messages'] = self.messages.map(&:api_json)
     end
-    %w(from_address from_city to_address to_city special_requests).each do |field|
+    %w(from_address from_city to_address to_city special_requests ).each do |field|
       j[field] = CGI::escape_html(send(field) || '')
     end
     last_msg = self.messages.order('created_at ASC').last
@@ -54,6 +54,7 @@ class Conversation < ApplicationRecord
     j['status_updated_at'] = self.status_updated_at.to_i
     j['name'] = CGI::escape_html(username || '')
     j['ride'] = ride.api_json if ride
+    j['blacklisted_phone_number'] = self.blacklisted_phone.phone if self.blacklisted_phone.present?
     j
   end
 

--- a/app/views/admin/ride_zones/edit.html.haml
+++ b/app/views/admin/ride_zones/edit.html.haml
@@ -14,7 +14,7 @@
   %p{style: "background-color: #ffffe0; font-size: 20px; font-weight: bold;"}
     = flash[:notice]
 
-%table
+%table.col-sm-9
   %th
     %tr
       %td
@@ -43,7 +43,7 @@
           Add admin:
           %select#add-admin
             %option
-            = options_for_select( (@local_users-@zone_admins).map{ |u| [u.name, u.id] } )
+            = options_for_select( (@zone_dispatchers).map{ |u| [u.name, u.id] } )
 
       %td
         - if @zone_dispatchers.present?
@@ -57,7 +57,7 @@
           Add dispatcher:
           %select#add-dispatcher
             %option
-            = options_for_select( (@local_users-@zone_dispatchers).map{ |u| [u.name, u.id] } )
+            = options_for_select( (@zone_drivers + @zone_unassigned_drivers).map{ |u| [u.name, u.id] } )
 
       %td
         - if @zone_drivers.present?
@@ -71,7 +71,8 @@
           Add driver:
           %select#add-driver
             %option
-            = options_for_select( (@local_users-@zone_drivers).map{ |u| [u.name, u.id] } )
+            / = options_for_select( (@local_users-@zone_drivers).map{ |u| [u.name, u.id] } )
+            = options_for_select( (@zone_unassigned_drivers).map{ |u| [u.name, u.id] } )
 
 :javascript
 

--- a/app/views/admin/ride_zones/index.html.haml
+++ b/app/views/admin/ride_zones/index.html.haml
@@ -8,9 +8,10 @@
 
 %h1
   Ride Zones
-  &nbsp;
-  %small
-    = link_to 'New Ride Zone', new_admin_ride_zone_path, class: 'btn btn-default btn-xs'
+  - if current_user.is_super_admin?
+    &nbsp;
+    %small
+      = link_to 'New Ride Zone', new_admin_ride_zone_path, class: 'btn btn-default btn-xs'
 
 %table.table-striped.admin
   %thead

--- a/app/views/application/_footer.html.haml
+++ b/app/views/application/_footer.html.haml
@@ -1,18 +1,13 @@
 
+
 %footer
-  .pull-right{style: 'margin: 5px 150px 0 0;'}
+  .privacy.pull-right
     = link_to 'privacy', privacy_path
     
   %div{class: "container#{(@fluid.present?) ? '-fluid' : ''}"}
     .center
       %table
         %tr
-          %td.fb
-            <div class="fb-share-button" data-href="https://www.drive.vote" data-layout="button" data-size="small" data-mobile-iframe="true"><a class="fb-xfbml-parse-ignore" target="_blank" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.drive.vote%2F&amp;src=sdkpreparse">Share</a></div>
-
-          %td.tw
-            %a.twitter-share-button{href: "http://twitter.com/intent/tweet?text=Give%20or%20get%20free%20rides%20to%20the%20polls%20with%20Drive%20the%20Vote!&amp;url=https://www.drive.vote&amp;via=drivevote&amp;related=wordie", target: '_blank'}
-
           %td.email
             #{mail_to 'hello@drive.vote', 'hello@drive.vote'}
 

--- a/app/views/application/_nav.html.haml
+++ b/app/views/application/_nav.html.haml
@@ -15,6 +15,11 @@
 
     #navbar.collapse.navbar-collapse
       .pull-right.nav-links
+      
+        = link_to 'Privacy', privacy_path, class: 'visible-xs-inline'
+        
+        .visible-xs-inline
+          &nbsp; &#183; &nbsp;
 
         - unless user_signed_in?
           = link_to t(:sign_in), new_user_session_path
@@ -26,13 +31,13 @@
           &nbsp; &#183; &nbsp;
 
           - if current_user.is_super_admin? || current_user.is_zone_admin?
-            = link_to 'admin', admin_ride_zones_path, style: 'color: red;'
+            = link_to 'Admin', admin_ride_zones_path, style: 'color: red;'
 
           - elsif current_user.is_dispatcher?
-            = link_to 'dispatch', dispatch_path( RideZone.with_user_in_role(current_user, :dispatcher).first.slug), target: '_blank'
+            = link_to 'Dispatch', dispatch_path( RideZone.with_user_in_role(current_user, :dispatcher).first.slug), target: '_blank'
 
           - elsif current_user.is_driver?
-            = link_to 'driving app', driving_index_path
+            = link_to 'Driving app', driving_index_path
 
 
         .btn.btn-info.btn-xs{style: 'margin: 5px 0 0 20px;'}

--- a/app/views/dispatch/_messages.html.haml
+++ b/app/views/dispatch/_messages.html.haml
@@ -11,6 +11,13 @@
 -# just to make the javascript below a little easier to read
 - close_button = j( link_to 'Cancel Ride', '#', class: 'btn btn-xs btn-warning archive-convo' )
 
+
+- if @conversation.voter_phone_blacklisted?
+  - block_button = j( link_to 'Unblock #', '#', class: 'btn btn-default btn-xs unblock-convo' )
+- else
+  - block_button = j( link_to 'Block #', '#', class: 'btn btn-danger btn-xs block-convo' )
+  
+
 - if @conversation.user.name.include?('via sms')
   - title = @conversation.from_phone.phony_formatted(normalize: :US, spaces: '-')
 - else
@@ -25,7 +32,9 @@
     $(this).text( strftime('%l:%M%P', new Date( $(this).text()*1000)) );
   });
 
-  $('#archive-btn').html("<span style='font-weight: normal;'>#{close_button}</span>")
+  $('#archive-btn').html("<span style='font-weight: normal;'>#{close_button}</span> \
+  <span style='font-weight: normal;'>#{block_button}</span> \
+  ")
 
   $('.archive-convo').click(function(e) {
     if (confirm("Are you sure? This will end the conversation and cancel the ride no matter what state it is in, and you will not be able to reopen or reassign it. This is a complete cancellation of this voter's ride" )) {
@@ -34,6 +43,28 @@
         humane.log ('Conversation archived');
       }).fail(function() {
         humane.log ('Unable to archive conversation');
+      });
+    }
+    e.preventDefault();
+  });
+  
+  $('.unblock-convo').click(function(e) {
+    if (confirm("Are you sure you want to unblock phone number #{@conversation.from_phone}?" )) {
+      $.post( "#{unblacklist_voter_phone_admin_conversation_path(@conversation)}", function(responseData, status, xhr) {
+        humane.log ('number unblocked');
+      }).fail(function() {
+        humane.log ('Unable to unblock number');
+      });
+    }
+    e.preventDefault();
+  });
+  
+  $('.block-convo').click(function(e) {
+    if (confirm("Are you sure you want to permanently block this phone number, #{@conversation.from_phone}?" )) {
+      $.post( "#{blacklist_voter_phone_admin_conversation_path(@conversation)}", function(responseData, status, xhr) {
+        humane.log ('number blocked');
+      }).fail(function() {
+        humane.log ('Unable to block number');
       });
     }
     e.preventDefault();

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -43,7 +43,9 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 
   config.assets.quiet = true
-
+  
+  config.log_level = :debug
+  
   logger = ActiveSupport::Logger.new(STDOUT)
   logger.formatter = config.log_formatter
   config.logger = ActiveSupport::TaggedLogging.new(logger)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,67 +6,6 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-admin = User.create!(
-  name: 'Generic Admin',
-  available: false,
-  email: 'seeds@drive.vote',
-  password: '1234abcd',
-  phone_number_normalized: '+15550222222',
-  locale: 'en',
-)
-
-
-john = User.create!(
-  name: 'John McGrath',
-  available: false,
-  email: 'john@fnnny.com',
-  password: '1234abcd',
-  phone_number: '5552222222',
-  phone_number_normalized: '+15554222223',
-  locale: 'en',
-  address1: '1100 Nugget Ave',
-  city: 'San Francisco',
-  state: 'CA'
-)
-
-# adam = User.create!(
-#   name: 'Adam McAmis',
-#   available: false,
-#   email: 'mcamis@gmail.com',
-#   password: '1234abcd',
-#   phone_number_normalized: '+15550222222',
-#   locale: 'en',
-# )
-
-# albert = User.create!(
-#   name: 'Albert Wong',
-#   available: false,
-#   email: 'awong.public@gmail.com',
-#   password: '1234abcd',
-#   phone_number_normalized: '+15551222222',
-#   locale: 'en',
-# )
-#
-# erin = User.create!(
-#   name: 'Erin Germ',
-#   available: false,
-#   email: 'erin@eringerm.com',
-#   password: '1234abcd',
-#   phone_number_normalized: '+15552222222',
-#   locale: 'en',
-# )
-#
-# gerald = User.create!(
-#   name: 'Gerald Huff',
-#   available: false,
-#   email: 'gerald.huff@gmail.com',
-#   password: '1234abcd',
-#   phone_number_normalized: '+15553222222',
-#   locale: 'en',
-#   city: 'Berkeley',
-#   state: 'CA'
-# )
-
 roles = Role.create([
   {name: 'admin'},
   {name: 'dispatcher'},
@@ -75,14 +14,6 @@ roles = Role.create([
   {name: 'voter'},
 ])
 
-admin.add_role(:admin)
-# adam.add_role(:admin)
-# albert.add_role(:admin)
-# erin.add_role(:admin)
-# gerald.add_role(:admin)
-john.add_role(:admin)
-
-# if  Rails.env == "development"
 zones = RideZone.create!([
   {
     name: 'Berkeley, CA',
@@ -98,7 +29,7 @@ zones = RideZone.create!([
   },
   {
     name: 'San Francisco, CA',
-    phone_number: '+14152002626',
+    phone_number: '+14158519528',
     slug: 'san_francisco',
     city: 'San Francisco',
     state: 'CA',
@@ -122,24 +53,67 @@ zones = RideZone.create!([
   }
 ])
 
+sf = RideZone.find_by_slug('san_francisco')
+orlando = RideZone.find_by_slug('orlando')
+
+generic_admin = User.create!(
+  name: 'Generic Admin',
+  available: false,
+  email: 'seeds@drive.vote',
+  password: '1234abcd',
+  phone_number: '5552222222',
+  phone_number_normalized: '+15550222222',
+  locale: 'en',
+)
+
+john = User.create!(
+  name: 'John McGrath',
+  available: false,
+  email: 'john@fnnny.com',
+  password: '1234abcd',
+  phone_number: '5552222223',
+  phone_number_normalized: '+15554222223',
+  locale: 'en',
+  address1: '1100 Nugget Ave',
+  city: 'San Francisco',
+  state: 'CA'
+)
+
+sf_admin =  User.create!(
+  name: 'SF Zone Admin',
+  available: false,
+  email: 'sfadmin@fnnny.com',
+  password: '1234abcd',
+  phone_number: '5552222224',
+  phone_number_normalized: '+15554222224',
+  locale: 'en',
+  address1: '1100 Nugget Ave',
+  city: 'San Francisco',
+  state: 'CA'
+)
+
+generic_admin.add_role(:admin)
+john.add_role(:admin)
+sf_admin.add_role(:admin, sf)
+
 drivers = User.create!([
   {
     name: 'Deborah Driver',
     available: false,
     email: 'deborah@fnnny.com',
     password: '1234abcd',
-    phone_number: '2123328709',
-    phone_number_normalized: '+15555222222',
+    phone_number: '2073328709',
+    phone_number_normalized: '+12073328709',
     image_url: '',
     locale: 'en',
-    zip: '84122'
+    zip: '94121'
   }, {
     name: 'Doug Driver',
     available: false,
     email: 'doug@fnnny.com',
     password: '1234abcd',
-    phone_number: '2133328709',
-    phone_number_normalized: '+15556222222',
+    phone_number: '5552222226',
+    phone_number_normalized: '+15556222226',
     image_url: '',
     locale: 'en',
     zip: '84122'
@@ -148,8 +122,8 @@ drivers = User.create!([
     available: false,
     email: 'danny@fnnny.com',
     password: '1234abcd',
-    phone_number: '2133328710',
-    phone_number_normalized: '+15556222222',
+    phone_number: '5552222227',
+    phone_number_normalized: '+15556222227',
     image_url: '',
     locale: 'en',
     zip: '84122'
@@ -158,17 +132,30 @@ drivers = User.create!([
     available: false,
     email: 'donnie@fnnny.com',
     password: '1234abcd',
-    phone_number: '2133328711',
-    phone_number_normalized: '+15556222222',
+    phone_number: '5552222228',
+    phone_number_normalized: '+15556222228',
     image_url: '',
     locale: 'en',
     zip: '84122'
   }
 ])
 
-sf = RideZone.find_by_slug('san_francisco')
-orlando = RideZone.find_by_slug('orlando')
+dispatchers = User.create!([
+  name: 'SF Dispatcher',
+  available: false,
+  email: 'sfdispatch@fnnny.com',
+  password: '1234abcd',
+  phone_number: '5552222229',
+  phone_number_normalized: '+15554222229',
+  locale: 'en',
+  address1: '1100 Nugget Ave',
+  city: 'San Francisco',
+  state: 'CA'
+])
+
 drivers[0].add_role(:unassigned_driver, sf)
-drivers[1].add_role(:driver, orlando)
-drivers[2].add_role(:driver, orlando)
-drivers[2].add_role(:unassigned_driver, orlando)
+drivers[1].add_role(:driver, sf)
+drivers[2].add_role(:driver, sf)
+drivers[3].add_role(:unassigned_driver, orlando)
+
+dispatchers[0].add_role(:dispatcher, sf)

--- a/spec/requests/admin/conversations_spec.rb
+++ b/spec/requests/admin/conversations_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "Conversations", type: :request do
 
     it "redirects if you're not logged in" do
       get admin_conversations_path
+      # expect(response).to have_http_status(404)
       expect(response).to have_http_status(302)
     end
 
@@ -13,6 +14,7 @@ RSpec.describe "Conversations", type: :request do
       sign_in user
 
       get admin_conversations_path
+      # expect(response).to have_http_status(404)
       expect(response).to have_http_status(302)
     end
 
@@ -25,4 +27,18 @@ RSpec.describe "Conversations", type: :request do
     end
 
   end
+  
+  # describe "POST /admin/converations/{}/blacklist_voter_phone" do
+  #   let!(:rz) { create :ride_zone }
+  #   let!(:conversation) { create :conversation, ride_zone: rz }
+  #
+  #   it "succeeds if you're logged in as an admin" do
+  #     user = create(:admin_user)
+  #     sign_in user
+  #
+  #     post blacklist_voter_phone_admin_conversation_path(conversation)
+  #     puts "response---------> #{response.status.inspect}"
+  #     expect(response).to have_http_status 302
+  #   end
+  # end
 end


### PR DESCRIPTION
Bit of a mishmash, main change is that this allows dispatchers to block phone numbers, previously had been only ride zone admins who could do it. So it reuses the existing blocking code, and just adds a 'Block' button to the RZ modal, and lifts the admin restriction on the controller for blocking.

Also some ad hoc fixes to the ride zone admin pages, previously they were showing all drivers across all ride zones as promotable, it's now scoped just to the ride zone you're looking at.

A few style tweaks to the footer too.

Closes #975