### PR TITLE
Call status endpoint on a set interval

### DIFF
--- a/app/javascript/driving/containers/DriverStatusContainer.js
+++ b/app/javascript/driving/containers/DriverStatusContainer.js
@@ -4,9 +4,20 @@ import RideContainer from './RideContainer';
 import Unavailable from '../components/Unavailable';
 import Loading from '../components/Loading';
 
+const FETCH_STATUS_INTERVAL = 60000;
+
 class DriverStatusContainer extends React.Component {
   componentDidMount() {
     this.props.fetchStatus();
+
+    this.statusInterval = setInterval(
+      () => this.props.fetchStatus(),
+      FETCH_STATUS_INTERVAL
+    );
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.statusInterval);
   }
 
   render() {

--- a/app/javascript/driving/containers/RideContainer.js
+++ b/app/javascript/driving/containers/RideContainer.js
@@ -28,6 +28,9 @@ class RideContainer extends React.Component {
     );
   }
 
+  /**
+   * Update interval functions if API-based delays have changed
+   */
   UNSAFE_componentWillReceiveProps({
     waiting_rides_interval: nextRidesInterval,
     update_location_interval: nextLocationInterval,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - .:/dtv
     ports:
       - "3000:3000"
+      - "8080:8080"
     depends_on:
       - db
     stdin_open: true


### PR DESCRIPTION
Implements #890 
* Sends a GET request to the `/status` endpoint every 60 seconds

`DriverStatusContainer` is mounted as soon as a driver allows location sharing. Previously this would only check the status just once per session.

@John is this safe to hardcode, or would you like utilize another server-supplied interval, e.g. `waiting_rides_interval`/`update_location_interval`?