### PR TITLE
heroku docker base, RDS in prod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,25 @@
-FROM ruby:2.5.1-alpine3.7
+# --- Select the image you'd like to use locally
+# FROM ruby:2.5.1-alpine3.7
+FROM heroku/heroku:18-build
 
-RUN apk update
-RUN apk add \
+# --- For Alpine image
+# RUN apk update
+# RUN apk add \
+#   bash \
+#   build-base \
+#   git \
+#   nodejs \
+#   python3 \
+#   postgresql-dev \
+#   postgresql-client \
+#   tzdata \
+#   yarn \
+#   && rm -rf /var/cache/apk/*
+
+# --- For Heroku image
+RUN apt-get update && apt-get install -y \
   bash \
   build-base \
-  git \
   nodejs \
   python3 \
   postgresql-dev \
@@ -13,7 +28,6 @@ RUN apk add \
   yarn \
   && rm -rf /var/cache/apk/*
 
-# RUN gem install bundler
 
 # First copy the bundle files and install gems to aid caching of this layer
 WORKDIR /tmp

--- a/config/database.yml
+++ b/config/database.yml
@@ -23,8 +23,9 @@ test:
 # http://alumni.lewagon.org/questions/67
 production:
   <<: *default
-  database: <%= ENV['RDS_DB_NAME'] %>
+  host: <%= ENV['RDS_HOSTNAME'] %>
+  database: vote_production
   username: <%= ENV['RDS_USERNAME'] %>
   password: <%= ENV['RDS_PASSWORD'] %>
-  host: <%= ENV['RDS_HOSTNAME'] %>
+  
   port: <%= ENV['RDS_PORT'] %>


### PR DESCRIPTION
This PR updates the Heroku production environment to RDS, and standardized images across dev, staging, and prod:

- database.yml is updated to use RDS endpoints for the DB.
- The Dockerfile is updated to use the same base image as is being used in staging and production. Previously staging had been using the heroku-16 base image, production cedar-14, and the local Dockerfile was based on Alpine. Now staging and production have been updated to heroku-18 via the Heroku console, and the local Dockerfile updated to use heroku-18-build, for a consistency across environments.

Closes #968