### PR TITLE
Update cancel copy, fix ws origin, remove twitter

### DIFF
--- a/app/javascript/driving/components/ActiveRide.js
+++ b/app/javascript/driving/components/ActiveRide.js
@@ -78,10 +78,10 @@ const renderButtons = props => {
             className="btn btn-danger btn-api"
             onClick={() => cancelRide(ride)}
           >
-            Cancel Ride
+            Cancel Pickup
           </button>
           <p className="text-center">
-            Cancelling a ride will make it available to other drivers
+            Makes available to other drivers
           </p>
           <button
             className="btn btn-outline btn-api m-t-md"
@@ -90,7 +90,7 @@ const renderButtons = props => {
             Archive Ride
           </button>
           <p className="text-center">
-            Archive a ride when a rider has already voted.
+            Removes entirely (noshow, already voted)
           </p>
         </React.Fragment>
       );
@@ -110,7 +110,7 @@ const renderButtons = props => {
             className="btn btn-danger btn-api"
             onClick={() => cancelRide(ride)}
           >
-            Cancel Ride
+            Cancel Pickup
           </button>
         </React.Fragment>
       );

--- a/app/views/application/_footer.html.haml
+++ b/app/views/application/_footer.html.haml
@@ -10,21 +10,3 @@
         %tr
           %td.email
             #{mail_to 'hello@drive.vote', 'hello@drive.vote'}
-
-:javascript
-  window.twttr = (function(d, s, id) {
-    var js, fjs = d.getElementsByTagName(s)[0],
-      t = window.twttr || {};
-    if (d.getElementById(id)) return t;
-    js = d.createElement(s);
-    js.id = id;
-    js.src = "https://platform.twitter.com/widgets.js";
-    fjs.parentNode.insertBefore(js, fjs);
-
-    t._e = [];
-    t.ready = function(f) {
-      t._e.push(f);
-    };
-
-    return t;
-  }(document, "script", "twitter-wjs"));

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -5,8 +5,8 @@ Rails.application.configure do
   Rails.env = 'development'
 
   # Websocket for messages
-  config.action_cable.url = "ws://local.drive.vote:3000/cable"
-  config.action_cable.allowed_request_origins = ['http://local.drive.vote:3000']
+  config.action_cable.url = "ws://localhost:3000/cable"
+  config.action_cable.allowed_request_origins = ['http://local.drive.vote:3000', 'http://localhost:3000']
 
   # Settings specified here will take precedence over those in config/application.rb.
 


### PR DESCRIPTION
- 'Tweet this' button was removed, so Twitter call was pointless and failed
- Copyedits to driver app to clarify the difference between cancelling and archiving
- App should be run on localhost now, not an alias, so update ws:// origin to reflect that