### PR TITLE
Render key and controls for large map, move to a partial

### DIFF
--- a/app/views/dispatch/_map_key.html.haml
+++ b/app/views/dispatch/_map_key.html.haml
@@ -1,0 +1,28 @@
+%table.key{style: 'margin-bottom: 30px;'}
+  %tr
+    %td.key-pin-cell= image_tag "rider-waiting-assignment.png", class: 'key-pin-img'
+    %td.key-label     Voter needs a driver
+    %td.key-pin-cell= image_tag "driver-waiting-assignment.png", class: 'key-pin-img'
+    %td.key-label     Available driver
+    %td{rowspan: 3, style: 'text-align: center'}
+      #dispatch-map-controls{style: 'margin-bottom: 1em; display:none'}
+        %button.btn.btn-success.btn-xs#show-all-pins
+          Show all pins
+        %br
+        %span#out-of-bounds-message{style: 'color: #666; font-size: 13px;'}
+
+  %tr
+    %td.key-pin-cell= image_tag "rider-overdue-assignment.png", class: 'key-pin-img'
+    %td.key-label     Voter overdue assignment
+    %td.key-pin-cell= image_tag "driver-assigned.png", class: 'key-pin-img'
+    %td.key-label     Assigned driver
+  %tr
+    %td.key-pin-cell= image_tag "rider-waiting-pickup.png", class: 'key-pin-img'
+    %td.key-label     Voter waiting for pickup
+    %td.key-pin-cell= image_tag "driver-driving.png", class: 'key-pin-img'
+    %td.key-label     Driving
+  %tr
+    %td.key-pin-cell= image_tag "rider-overdue-pickup.png", class: 'key-pin-img'
+    %td.key-label     Voter pickup overdue
+    %td.key-pin-cell= image_tag "driver-driving-overdue.png", class: 'key-pin-img'
+    %td.key-label     Completion overdue

--- a/app/views/dispatch/map.html.haml
+++ b/app/views/dispatch/map.html.haml
@@ -3,5 +3,8 @@
 .col-md-12{style: 'margin-top: 10px;'}
   #dispatch-map
 
+.col-md-12{style: 'margin-top: 10px;'}
+  = render partial: 'dispatch/map_key'
+
 :javascript
   #{render partial: 'dispatch/init.js'}

--- a/app/views/dispatch/show.html.haml
+++ b/app/views/dispatch/show.html.haml
@@ -67,35 +67,7 @@
     #dispatch-map
 
     .pull-left
-      %table.key{style: 'margin-bottom: 30px;;'}
-        %tr
-          %td.key-pin-cell= image_tag "rider-waiting-assignment.png", class: 'key-pin-img'
-          %td.key-label     Voter needs a driver
-          %td.key-pin-cell= image_tag "driver-waiting-assignment.png", class: 'key-pin-img'
-          %td.key-label     Available driver
-          %td{rowspan: 3, style: 'text-align: center'}
-            #dispatch-map-controls{style: 'margin-bottom: 1em; display:none'}
-              %button.btn.btn-success.btn-xs#show-all-pins
-                Show all pins
-              %br
-              %span#out-of-bounds-message{style: 'color: #666; font-size: 13px;'}
-
-        %tr
-          %td.key-pin-cell= image_tag "rider-overdue-assignment.png", class: 'key-pin-img'
-          %td.key-label     Voter overdue assignment
-          %td.key-pin-cell= image_tag "driver-assigned.png", class: 'key-pin-img'
-          %td.key-label     Assigned driver
-        %tr
-          %td.key-pin-cell= image_tag "rider-waiting-pickup.png", class: 'key-pin-img'
-          %td.key-label     Voter waiting for pickup
-          %td.key-pin-cell= image_tag "driver-driving.png", class: 'key-pin-img'
-          %td.key-label     Driving
-        %tr
-          %td.key-pin-cell= image_tag "rider-overdue-pickup.png", class: 'key-pin-img'
-          %td.key-label     Voter pickup overdue
-          %td.key-pin-cell= image_tag "driver-driving-overdue.png", class: 'key-pin-img'
-          %td.key-label     Completion overdue
-
+      = render partial: 'dispatch/map_key'
 
 :javascript
 


### PR DESCRIPTION
Fixes #985 
Adds the map key & UI controls to the large map template so that dispatch_map JS event listeners won't error out on non-existing DOM elements.