### PR TITLE
send email when driver is approved (fixes #715)

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -14,6 +14,13 @@ class UserMailer < ApplicationMailer
 
   # http://templates.mailchimp.com/resources/inline-css/
   
+  def notify_driver_approved(user, ride_zone)
+    @user = user
+    @ride_zone = ride_zone
+
+    mail(to: @user.email_with_name, subject: 'You\'re approved to drive')
+  end
+
   def notify_scheduled_ride(ride)
     @ride = ride
     @user = ride.voter

--- a/app/views/user_mailer/notify_driver_approved.html.erb
+++ b/app/views/user_mailer/notify_driver_approved.html.erb
@@ -1,0 +1,15 @@
+<h1 style="font-family: &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Lucida Grande&quot;, sans-serif;font-size: 36px;line-height: 1.2em;margin: 40px 0 15px;padding: 0;color: #111111;font-weight: 200;">
+
+  Welcome <%= @user.name %>!</h1>
+
+<p style="font-family: &quot;Helvetica Neue&quot;, &quot;Helvetica&quot;, Helvetica, Arial, sans-serif;font-size: 16px;line-height: 1.6em;margin: 0;padding: 0;font-weight: normal;margin-bottom: 12px;">
+  Your offer to drive for <b><%= @ride_zone.name %></b> has been approved! Someone will be in touch with you prior to Election Day with further instructions.
+</p>
+
+<p style="font-family: &quot;Helvetica Neue&quot;, &quot;Helvetica&quot;, Helvetica, Arial, sans-serif;font-size: 16px;line-height: 1.6em;margin: 0;padding: 0;font-weight: normal;margin-bottom: 12px;">
+  Email
+  <% if @ride_zone.present? %><a href="mailto:<%= @ride_zone.email %>"><%= @ride_zone.email %></a> or <% end %>
+  <a href="mailto:hello@drive.vote">hello@drive.vote</a> if you have questions or need help.
+</p>
+
+<p style="font-family: &quot;Helvetica Neue&quot;, &quot;Helvetica&quot;, Helvetica, Arial, sans-serif;font-size: 16px;line-height: 1.6em;margin: 0;padding: 0;font-weight: normal;margin-bottom: 12px;">Thank your for volunteering--you're making a difference.</p>

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -12,8 +12,8 @@ class UserMailerPreview < ActionMailer::Preview
 
   def welcome_email_voter_ride
     user = User.first
-    rz = RideZone.create(name: 'Tampa', slug: 'tampa')
-    ride = Ride.new(voter_id: user.id, ride_zone_id: rz.id, pickup_at: Time.now, from_address: "330 Cabrillo St.", from_city: "Tampa, FL")
+    rz = RideZone.create(name: 'Tampa', slug: 'tampa', email: 'tampa_admin@example.com')
+    ride = Ride.new(voter_id: user.id, ride_zone: rz, pickup_at: Time.now, from_address: "330 Cabrillo St.", from_city: "Tampa, FL")
 
     UserMailer.welcome_email_voter_ride(user, ride)
   end
@@ -27,6 +27,12 @@ class UserMailerPreview < ActionMailer::Preview
     user = User.first
     rz = RideZone.create(name: 'Tampa', slug: 'tampa')
     UserMailer.welcome_email_driver(user, rz)
+  end
+
+  def notify_driver_approved
+    user = User.first
+    rz = RideZone.create(name: 'Tampa', slug: 'tampa', email: 'tampa_admin@example.com')
+    UserMailer.notify_driver_approved(user, rz)
   end
 
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -271,7 +271,7 @@ RSpec.describe User, :type => :model do
     expect(u.reload.location_updated_at).to_not be_nil
   end
 
-  describe 'enqueues email on creation' do
+  describe 'enqueues email' do
     let(:dummy_mailer) { OpenStruct.new(deliver_later: nil) }
 
     it 'sends driver email for web registration' do
@@ -283,6 +283,15 @@ RSpec.describe User, :type => :model do
       expect(UserMailer).to_not receive(:welcome_email_voter)
       create :sms_voter_user
     end
+
+    it 'sends driver email when approved' do
+      rz = create :ride_zone
+      u = create :unassigned_driver_user, rz: rz
+
+      expect(UserMailer).to receive(:notify_driver_approved) { dummy_mailer }
+      u.add_role(:driver, rz)
+    end
+
   end
 
   describe 'event generation' do


### PR DESCRIPTION
First (er, second 😕) stab at #715, notifying driver they've been approved/assigned. Draft of email view (also visible in the [previewer](http://localhost:3000/rails/mailers/user_mailer/notify_driver_approved) if you're running locally) is below.

<img width="502" alt="screen shot 2018-10-08 at 9 15 08 pm" src="https://user-images.githubusercontent.com/5596/46672319-b95cbf00-cb9c-11e8-9a4f-fc9f10a85f03.png">
