### PR TITLE
add ability for ride-zone admins to set drivers on or off duty

### DIFF
--- a/app/controllers/admin/drivers_controller.rb
+++ b/app/controllers/admin/drivers_controller.rb
@@ -22,4 +22,18 @@ class Admin::DriversController < Admin::AdminApplicationController
     end
   end
 
+  def toggle_available
+    if params[:id].present?
+      driver = User.find(params[:id])
+
+      driver.update_attribute :available, !driver.available
+      driver.save!
+      msg = "#{driver.name} is now #{driver.available? ? 'on' : 'off'} duty"
+    else
+      msg = "I can't really do anything without a driver ID."
+    end
+
+    flash[:notice] = msg
+    redirect_back(fallback_location: root_path)
+  end
 end

--- a/app/views/dispatch/drivers.html.haml
+++ b/app/views/dispatch/drivers.html.haml
@@ -22,11 +22,18 @@
     = link_to 'Download .csv', drivers_dispatch_path(format: 'csv'), class: 'btn btn-info btn-xs'
 
   &nbsp;&nbsp; &#183; &nbsp;&nbsp;
-  🔵 = on duty &nbsp;&nbsp;&nbsp;&nbsp; 🔴 = off duty
+  -# &#128308; = red_circle, &#128309; = blue_circle, &#128661; = taxi
+  &#128309; = on duty &nbsp;&nbsp;&nbsp;&nbsp; &#128308; = off duty &nbsp;&nbsp;&nbsp; &#128661; = mid-ride
 
 :javascript
   $('.sort').change(function() {
     window.location.href = window.location.pathname + "?sort=" + $('.sort option:selected').val();;
+  });
+
+  $(document).ready(function() {
+    $(".no-off-duty").click(function() {
+       alert("You can't take a driver off duty when they are in the middle of a ride.\nAssign a new driver or archive the ride first.");
+    });
   });
 
 .col-md-12
@@ -49,9 +56,9 @@
         %tr
           %td
             = driver.name
-            = driver.available? ? '🔵 ' : '🔴 '
+            != driver.available? ? '&#128309; ' : '&#128308; '
             - if driver.active_ride.present?
-              🚕
+              &#128661;
           %td
             = mail_to driver.email
           %td
@@ -62,6 +69,17 @@
           - if current_user.has_role?(:admin, @ride_zone) || current_user.is_super_admin?
             %td
               = link_to 'demote', change_role_admin_ride_zone_path(@ride_zone, to_role: 'unassigned_driver', driver: driver.id), method: :post
+            %td
+              - if driver.available?
+                -# pause-button emoji
+                - if driver.active_ride.present?
+                  %span.no-off-duty{title: "cannot take driver off duty mid-ride"}
+                    &#9208;
+                - else
+                  = link_to raw('&#9208;'), toggle_available_admin_driver_path(id: driver.id), method: :post, title: "take driver off duty"
+              - else
+                -# play-button emoji
+                = link_to raw('&#9654;'), toggle_available_admin_driver_path(id: driver.id), method: :post, title: "put driver on duty"
 
     - else
       %tr

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -135,7 +135,11 @@ Rails.application.routes.draw do
         post 'unblacklist_voter_phone' => 'conversations#unblacklist_voter_phone'
       end
     end
-    resources :drivers, only: [:index]
+    resources :drivers, only: [:index] do
+      member do
+        post 'toggle_available'
+      end
+    end
     resources :metrics, only: [:index]
     resources :rides
     resources :ride_zones, only: [:index, :show, :new, :create, :edit, :update, :destroy] do

--- a/spec/controllers/admin/drivers_controller_spec.rb
+++ b/spec/controllers/admin/drivers_controller_spec.rb
@@ -19,4 +19,35 @@ RSpec.describe Admin::DriversController, type: :controller do
     end
   end
 
+  describe "toggle driver availability" do
+
+    context 'as admin' do
+      login_admin
+
+      it 'makes available driver unavailable' do
+        driver = create :driver_user
+        expect(driver.available).to be false  # verify default
+
+        post :toggle_available, params: {:id => driver.to_param}
+
+        driver.reload
+        expect(driver.available).to be true
+      end
+
+      it 'makes unavailable driver available' do
+        driver = create :driver_user
+        expect(driver.available).to be false # verify default
+
+        post :toggle_available, params: {:id => driver.to_param}
+        driver.reload
+        expect(driver.available).to be true # toggle once
+
+        post :toggle_available, params: {:id => driver.to_param}
+        driver.reload
+        expect(driver.available).to be false # toggle again
+      end
+
+    end
+  end
+
 end


### PR DESCRIPTION
Fixes #880. Also replaced emoji characters with HTML entities.

I went with play and pause emoji for the controls (e.g., ▶️ see screenshot), plus tooltips, thinking these will tend to be less-used controls anyway. Just let me know feedback on that; if text or anything else is preferred, that's no sweat, of course).

I also punted on handling this scenario if the driver is mid-ride - disallowing it (with an explanatory JS alert message) until the ride is removed. Happy to dig in further on that or add it in a future feature, whichever is preferred.

<img width="1197" alt="screen shot 2018-10-14 at 4 00 39 pm" src="https://user-images.githubusercontent.com/5596/46922203-39cf5580-cfcb-11e8-8f57-c82ade1efa05.png">
