### PR TITLE
fewer db calls, no sms option on ride creation

### DIFF
--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -83,19 +83,21 @@ class Conversation < ApplicationRecord
   # create a new conversation from the information in a completed ride object
   def self.create_from_ride(ride, thanks_msg)
     attrs = Conversation.ride_conversation_attrs(ride)
-    create_from_staff(ride.ride_zone, ride.voter, thanks_msg, Rails.configuration.twilio_timeout, attrs)
+    # set twilio timeout to -1 since we don't want to send a message
+    create_from_staff(ride.ride_zone, ride.voter, thanks_msg, -1, attrs, :ride_created)
   end
 
   # sets all fields in the conversation as completed based on ride info to prepare for bot
   # followup
   def mark_info_completed(ride)
-    update_attributes(Conversation.ride_conversation_attrs(ride))
+    # update_attributes(Conversation.ride_conversation_attrs(ride))
+    update(Conversation.ride_conversation_attrs(ride))
+    ride_created!
   end
 
   def self.ride_conversation_attrs(ride)
     {
       user: ride.voter,
-      status: :ride_created,
       ride: ride,
       from_address: ride.from_address,
       from_city: ride.from_city,
@@ -118,14 +120,14 @@ class Conversation < ApplicationRecord
 
   # create a new conversation initiated by staff
   # returns conversation if successful otherwise an error message
-  def self.create_from_staff(ride_zone, user, body, timeout, attrs = {})
+  def self.create_from_staff(ride_zone, user, body, timeout, attrs = {}, status = :in_progress)
     from_phone = ride_zone.phone_number_normalized
     to_phone = user.phone_number_normalized
     c = Conversation.create({ride_zone: ride_zone, user: user, from_phone: from_phone,
-                            to_phone: to_phone, status: :in_progress}.merge(attrs))
+                            to_phone: to_phone, status: status}.merge(attrs))
                             
     
-    if to_phone.present?
+    if to_phone.present? && timeout != -1
       sms = send_staff_sms(ride_zone, user, body, timeout)
       if sms.is_a?(String)
         # create dummy message so we know what we intended to send

--- a/app/models/potential_ride.rb
+++ b/app/models/potential_ride.rb
@@ -25,13 +25,14 @@ class PotentialRide < ApplicationRecord
   
   def populate_from_csv_row(row)
     row.each do |c|
-      if c[0] == 'pickup_at'
+      fieldname = c[0].downcase
+      if fieldname == 'pickup_at'
         pickup = Chronic.parse(c[1])
         pickup = pickup.change(month: '11', day: '06')
         self.pickup_at = pickup.utc
       else
         val = c[1].present? ? c[1] : ''
-        self.send "#{c[0]}=", val
+        self.send "#{fieldname}=", val
       end
     end
     self

--- a/app/models/ride.rb
+++ b/app/models/ride.rb
@@ -126,20 +126,18 @@ class Ride < ApplicationRecord
       conversation: conversation,
     }
     ActiveRecord::Base.transaction do
-      conversation.update_attribute(:status, :ride_created)
+      conversation.ride_created!
       Ride.create!(attrs)
     end
   end
   
-  def self.create_from_potential_ride( potential_ride, user )
-    potential_ride.voter = user
+  def self.create_from_potential_ride( potential_ride )
     attrs = {
       ride_zone: potential_ride.ride_zone,
       voter: potential_ride.voter,
       name: potential_ride.name,
       description: potential_ride.description || '',
       pickup_at: potential_ride.pickup_at,
-      status: :scheduled,
       from_address: potential_ride.from_address,
       from_city: potential_ride.from_city,
       from_state: potential_ride.from_state || '',
@@ -157,12 +155,11 @@ class Ride < ApplicationRecord
       potential_ride: potential_ride
     }
     ActiveRecord::Base.transaction do
-      potential_ride.update_attribute(:status, :converted)
       ride = Ride.new(attrs)
-      ride.save!
+      ride.scheduled!
       
       potential_ride.ride = ride
-      potential_ride.save!
+      potential_ride.converted!
       ride
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -59,7 +59,7 @@ class User < ApplicationRecord
 
   phony_normalize :phone_number, as: :phone_number_normalized, default_country_code: 'US'
 
-  validates_format_of :email, with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
+  validates_format_of :email, with: URI::MailTo::EMAIL_REGEXP
   validates_format_of :name, with: /\A[^"@\n]*\z/
   
   validates :phone_number_normalized, phony_plausible: true, allow_blank: true, uniqueness: { message: 'already in use by another account' }
@@ -86,7 +86,7 @@ class User < ApplicationRecord
   def self.html5_state_pattern
     "#{VALID_STATES.collect{|s| " #{s[0]}| #{s[0].downcase}|"}.join('')}"
   end
-
+  
   def self.autogenerate_email
     "#{Time.now.to_f}_#{rand(5 ** 10).to_s.rjust(5,'0')}@example.com"
   end
@@ -152,6 +152,7 @@ class User < ApplicationRecord
   
   def self.potential_ride_user_attrs( potential_ride )
     phone_number = potential_ride.phone_number.present? ? potential_ride.phone_number : ''
+    
     {
       name: potential_ride.name,
       email: potential_ride.email,

--- a/app/views/admin/ride_uploads/show.html.haml
+++ b/app/views/admin/ride_uploads/show.html.haml
@@ -2,7 +2,9 @@
   h1 { font-size: 20px; }
   .queued{background-color:orange; padding: 1px;}
   .pr {font-size: 13px;}
-  .no {margin-right: 5px; background-color:orange; padding: 1px;}
+  .pending {margin-right: 5px; background-color:yellow; padding: 1px;}
+  .fail {margin-right: 5px; background-color:red; padding: 1px;}
+  .no_ride {margin-right: 5px; background-color:orange; padding: 1px;}
   .yes {margin-right: 5px; background-color:green; color: white; padding: 1px;}
   .desc {margin-top: 0; }
 
@@ -34,8 +36,15 @@
 - @ride_upload.potential_rides.each do |pr|
   .pr
     - if pr.ride.blank?
-      %span.no
-        &nbsp;&nbsp;
+      - if pr.failed?
+        %span.fail
+          &nbsp;&nbsp;
+      - elsif pr.pending?
+        %span.pending
+          &nbsp;&nbsp;
+      - else
+        %span.no_ride
+          &nbsp;&nbsp;
     - else
       %span.yes
         &nbsp;&nbsp;
@@ -56,7 +65,7 @@
   %ul
     - @failed_potential_rides.each do |fpr|
       %li
-        = fpr.name
+        #{fpr.name} (#{fpr.notes})
     
 %hr
 %p

--- a/spec/controllers/admin/ride_uploads_controller_spec.rb
+++ b/spec/controllers/admin/ride_uploads_controller_spec.rb
@@ -67,7 +67,8 @@ RSpec.describe Admin::RideUploadsController, type: :controller do
         
         expect{
           post :create, params: {ride_zone_id: rz.id, ride_upload: {name: 'testup', csv: file }}
-        }.to change(RideUpload, :count).by(0)
+        }.to raise_error("Validation failed: Csv Must be a CSV file")
+        
       end
 
       # it "assigns a newly created scheduled_ride_upload as @scheduled_ride_upload" do

--- a/spec/models/ride_spec.rb
+++ b/spec/models/ride_spec.rb
@@ -375,7 +375,8 @@ RSpec.describe Ride, type: :model do
   it 'can be created from a potential_ride' do
     user = create :user
     potential_ride = create :potential_ride
-    ride = Ride.create_from_potential_ride( potential_ride, user )
+    potential_ride.voter = user
+    ride = Ride.create_from_potential_ride( potential_ride )
     expect(ride).to be_a Ride
     expect(potential_ride.status).to eq("converted")
   end

--- a/spec/requests/admin/conversations_spec.rb
+++ b/spec/requests/admin/conversations_spec.rb
@@ -28,17 +28,3 @@ RSpec.describe "Conversations", type: :request do
 
   end
   
-  # describe "POST /admin/converations/{}/blacklist_voter_phone" do
-  #   let!(:rz) { create :ride_zone }
-  #   let!(:conversation) { create :conversation, ride_zone: rz }
-  #
-  #   it "succeeds if you're logged in as an admin" do
-  #     user = create(:admin_user)
-  #     sign_in user
-  #
-  #     post blacklist_voter_phone_admin_conversation_path(conversation)
-  #     puts "response---------> #{response.status.inspect}"
-  #     expect(response).to have_http_status 302
-  #   end
-  # end
-end

--- a/spec/requests/admin/conversations_spec.rb
+++ b/spec/requests/admin/conversations_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe "Conversations", type: :request do
       get admin_conversations_path
       expect(response).to be_successful
     end
-
   end
+
+end
   


### PR DESCRIPTION
Changes:
- Fewer status changes. They're doing using Rails enum, so a DB call is triggered each time.
- Turn off SMS when bulk uploading rides. We may want to check with ride zone admins about preferred behavior.
- Comments on moving conversion of PotentialRides to Rides to an asynchronous job. That's how it should be done--any upload of more than 200 rides is likely to time out--but I wanted to improve the logic/DB interaction in a discrete step before doing that.