### PR TITLE
Add banner to warn about non-prod environments - fixes #1032

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'aws-sdk-s3', require: false
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'chronic', '0.10.2'
 gem 'coffee-rails' # shouldnt be necessary, not using, but one line in /spec/requests/dispatcher_spec.rb fails without it, super weirdly
-gem 'devise', '4.4.3'
+gem 'devise', '4.5.0'
 gem 'geocoder', '1.5.0'
 gem 'geokit-rails', '2.3.1'
 gem 'google-api-client', '0.10.1'

--- a/app/views/application/_staging_banner.html.haml
+++ b/app/views/application/_staging_banner.html.haml
@@ -1,0 +1,4 @@
+%div{style: 'background: red; color: white; padding-left: 1em;', id:'environment_warning_banner'}
+    You are viewing the 
+    %strong= Rails.env.upcase 
+    environment.

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -69,6 +69,9 @@
     js.src = "//connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.8&appId=598384123655141";
     fjs.parentNode.insertBefore(js, fjs);
     }(document, 'script', 'facebook-jssdk'));</script>
+    
+    - unless Rails.env.production?
+      = render partial: 'application/staging_banner'
 
     = render partial: 'application/nav', object: "container#{(@fluid.present?) ? '-fluid' : ''}", as: 'container_class'
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -31,7 +31,7 @@ Devise.setup do |config|
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
   # config.secret_key = 'something long and psuedorandom'
-  config.secret_key = Rails.application.credentials.secret_key_base
+  config.secret_key = Rails.application.secrets.secret_key_base
 
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -31,6 +31,7 @@ Devise.setup do |config|
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
   # config.secret_key = 'something long and psuedorandom'
+  config.secret_key = Rails.application.credentials.secret_key_base
 
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -31,7 +31,7 @@ Devise.setup do |config|
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
   # config.secret_key = 'something long and psuedorandom'
-  config.secret_key = Rails.application.secrets.secret_key_base
+  # config.secret_key = Rails.application.secrets.secret_key_base
 
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,

--- a/spec/requests/top_level_spec.rb
+++ b/spec/requests/top_level_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe "TopLevel", type: :request do
       expect(response).to have_http_status(301)
     end
 
+
     # TODO
     # it "serves the generic volunteer page" do
     #   get "/volunteer_to_drive"
@@ -73,5 +74,22 @@ RSpec.describe "TopLevel", type: :request do
       get privacy_path
       expect(response).to be_successful
     end
+
+    describe "lower-environment warning banner" do 
+      it "should show a warning banner when in staging (or other non-prod)" do 
+        allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("staging"))
+        get "/"
+        expect(response.body).to include("You are viewing the")
+        expect(response.body).to include("<strong>STAGING</strong>")
+      end
+  
+      it "should NOT show a warning banner when in production" do 
+        allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("production"))
+        get "/"
+        expect(response.body).to_not include("You are viewing the")
+        expect(response.body).to_not include("<strong>PRODUCTION</strong>")
+      end  
+    end
+
   end
 end


### PR DESCRIPTION
This fixes issue #1032 

If the Rails.env is 'production', the app displays as normal.
If the Rails.env is anything other than 'production', it displays a simple one-line white-on-red banner at the top of the page, with text similar to "You are viewing the STAGING environment". 

__NOTE__: this solution makes two key assumptions:
1) In production, Rails.env == 'production'
2) In staging, Rails.env !== 'production'