### PR TITLE
Fix and add spec for confirm_scheduled

### DIFF
--- a/app/controllers/api/v1/rides_controller.rb
+++ b/app/controllers/api/v1/rides_controller.rb
@@ -33,9 +33,14 @@ module Api::V1
       end
     end
 
+    # /api/1/rides/confirm_scheduled
     def confirm_scheduled
-      Ride.confirm_scheduled_rides
-      render text: 'ok'
+      if request.headers["X-Token"].present? && request.headers["X-Token"] == ENV["PING_API_SECRET"]
+        Ride.confirm_scheduled_rides
+        render plain: "OK"
+      else
+        head 404
+      end
     end
   end
 end

--- a/spec/requests/api/v1/rides_spec.rb
+++ b/spec/requests/api/v1/rides_spec.rb
@@ -17,4 +17,20 @@ RSpec.describe "Rides", type: :request do
       expect(response).to be_successful
     end
   end
+  
+  describe "GET /api/1/rides/confirm_scheduled" do
+    let(:ride) { create :ride }
+
+    it "404s with no auth key" do
+      post confirm_scheduled_api_v1_rides_path
+      expect(response).to have_http_status(404)
+    end
+
+    it "succeeds with X-Token header" do
+      allow(ENV).to receive(:[]).with("PING_API_SECRET").and_return("1234abcd")
+
+      post confirm_scheduled_api_v1_rides_path, headers: { 'X-Token' => "1234abcd" }
+      expect(response).to be_successful
+    end
+  end
 end


### PR DESCRIPTION
- `render :nothing` was removed in Rails 5.2, so switch to `render plain:`
- Require X-Token header rather than leaving it wide open
- Added specs