### PR TITLE
Send confirmation for scheduled rides

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Certain features require you to add a .env file to the root app directory contai
  
 You can generate the value for SECRET_KEY_BASE by running `bundle exec rake secret`.
 
-The Twilio values are used for sms interactions with voters and can be obtained from your Twilio account, which you'll also use to [create a Twilio number](https://github.com/john/drive.vote/wiki/Buying-and-Configuring-Twilio-Numbers) with sms capabilities, and update the ride zone you want to work with to use it.
+The Twilio values are used for sms interactions with voters and can be obtained from your Twilio account, which you'll also use to [create a Twilio number](https://github.com/john/drive.vote/wiki/Buying-and-Configuring-Twilio-Numbers) with sms capabilities, and update the ride zone you want to work with to use it. Using Twilio numbers during local dev requires setting up [ngrok](https://www.twilio.com/blog/2013/10/test-your-webhooks-locally-with-ngrok.html).
 
 GOOGLE_API_KEY is used for geolocation, and can be created in the [Google API console](https://console.cloud.google.com/apis/). Enable all geo APIs for the key.
 
@@ -82,7 +82,19 @@ If you don't want to use foreman, you have to run the rails server (Puma) and th
 
 If adding or modifying tests that will make new calls to the Google Maps APIs, you'll need to run with a valid `GOOGLE_API_KEY`, both to get your tests to pass, and also to refill the cached test data for use in later runs (including CI). See the discussion in `spec/rails_helpers.rb` for instructions on how to run with a live API Key.
 
-## Running the app locally
+## Running cron or a scheduled Lambda to promote rides
+
+A process needs to run every minute or so to check scheduled rides, and promote ones that are approaching their pickup time from 'scheduled' to 'waiting assignment,' so that they become available to drivers. That process needs to POST to this url, which will promote imminent rides: `/api/1/rides/confirm_scheduled`.
+
+The ideal production setup is to run a worker instance, so that it's not putting additional load on the web servers. Any instance acting as a worker (whether it's also a web server or not), needs to have the DTV_IS_WORKER env var set to TRUE.
+
+The call to confirm_scheduled can be made via a cron job, or if your environment doesn't support that (Heroku doesn't), a scheduled AWS Lambda.
+
+## The conversation bot
+
+In practice it turns out scheduled rides seem to be the primary use case. The app also supports on-demand rides via SMS. In that case information is gathered by a basic text bot, information about which can be found [here](https://github.com/john/drive.vote/blob/master/docs/converation_bot.md)
+
+## Using the app locally
 
 Go to http://localhost:3000 and log in as the generic admin with email `seeds@drive.vote` and password `1234abcd`. Since this account has admin privileges, logging in with it takes you directly to the admin site. If it has only driver privileges, it would take you to the driver app, and if only dispatcher privileges, to the dispatch page for the ride zone attached to your account. If for some reason your account has no privileges at all, you'll end up at the homepage, but that shouldn't happen. Note the accounts in seeds.rb don't exist in production, so don't get cute.
 

--- a/README.md
+++ b/README.md
@@ -86,13 +86,13 @@ If adding or modifying tests that will make new calls to the Google Maps APIs, y
 
 A process needs to run every minute or so to check scheduled rides, and promote ones that are approaching their pickup time from 'scheduled' to 'waiting assignment,' so that they become available to drivers. That process needs to POST to this url, which will promote imminent rides: `/api/1/rides/confirm_scheduled`.
 
-The ideal production setup is to run a worker instance, so that it's not putting additional load on the web servers. Any instance acting as a worker (whether it's also a web server or not), needs to have the DTV_IS_WORKER env var set to TRUE.
+The preferred production setup is to run a dedicated worker instance, but any instance acting as a worker (dedicated or not), needs to have the DTV_IS_WORKER env var set to TRUE.
 
-The call to confirm_scheduled can be made via a cron job, or if your environment doesn't support that (Heroku doesn't), a scheduled AWS Lambda.
+The call to confirm_scheduled can be made via cron or using the scheduled AWS Lambda [available in this repo.](https://github.com/john/drive.vote/blob/master/vendor/lambda/lambda_handler.py)
 
 ## The conversation bot
 
-In practice it turns out scheduled rides seem to be the primary use case. The app also supports on-demand rides via SMS. In that case information is gathered by a basic text bot, information about which can be found [here](https://github.com/john/drive.vote/blob/master/docs/converation_bot.md)
+In practice it turns out scheduled rides seem to be the primary use case. The app also supports on-demand rides via SMS. In that case information is gathered by a basic text bot, information about which can be found in [converation_bot.md](https://github.com/john/drive.vote/blob/master/docs/converation_bot.md)
 
 ## Using the app locally
 

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -33,7 +33,7 @@ class Conversation < ApplicationRecord
     info_complete: 1000,
     requested_confirmation: 1100,
   }
-  
+
   def api_json(include_messages = false)
     fields = [:id, :user_id, :pickup_at, :status, :lifecycle, :from_phone,
               :from_latitude, :from_longitude, :to_latitude, :to_longitude, :additional_passengers, :blacklisted_phone_number]
@@ -125,8 +125,8 @@ class Conversation < ApplicationRecord
     to_phone = user.phone_number_normalized
     c = Conversation.create({ride_zone: ride_zone, user: user, from_phone: from_phone,
                             to_phone: to_phone, status: status}.merge(attrs))
-                            
-    
+
+
     if to_phone.present? && timeout != -1
       sms = send_staff_sms(ride_zone, user, body, timeout)
       if sms.is_a?(String)
@@ -135,7 +135,7 @@ class Conversation < ApplicationRecord
       end
       Message.create_from_staff(c, sms)
     end
-    
+
     c
   end
 
@@ -187,7 +187,7 @@ class Conversation < ApplicationRecord
   def lifecycle_str
     self.lifecycle.gsub('_', ' ').titleize
   end
-  
+
   def message_count
     self.messages.count
   end
@@ -231,22 +231,21 @@ class Conversation < ApplicationRecord
     ActiveRecord::Base.transaction do
       ride.update_attributes(status: :waiting_assignment) if ride.status == 'scheduled'
       update_attributes(ride_confirmed: true)
-      
+
       body = I18n.t(:auto_confirmed_wait_for_driver, locale: user_language, time: ride.pickup_in_time_zone.strftime('%l:%M %P'))
-      
+
       sms = Conversation.send_staff_sms(ride_zone, user, body, Rails.configuration.twilio_timeout)
     end
-    return 'no_response_auto_confirm' # how is this used? Change to scheduled_ride_auto_confirm and then handle that, if it make sense.
     return 'scheduled_ride_auto_confirm'
   end
-  
+
   # This sends a text and they're confirmed if they respond to it with a '1'
   # returns a string with category of result
   def attempt_confirmation
     result = 'waiting_confirmation'
     if self.ride_confirmed.nil? && self.user
       body = I18n.t(:confirm_ride, locale: user_language, time: ride.pickup_in_time_zone.strftime('%l:%M %P'))
-      
+
       sms = Conversation.send_staff_sms(ride_zone, user, body, Rails.configuration.twilio_timeout)
       if Conversation.unreachable_phone_error(sms)
         # go ahead and promote b/c we can't reach the voter
@@ -256,15 +255,15 @@ class Conversation < ApplicationRecord
         end
         return 'bad_phone_auto_confirm'
       end
-      
+
       return 'twilio_error' if sms.is_a?(String) # error sending, will try again
-      
+
       ActiveRecord::Base.transaction do
         Message.create_from_bot(self, sms)
         update_attributes(ride_confirmed: false, bot_counter: 0, status: :ride_created)
       end
       result = 'sent_confirm_request'
-      
+
     elsif self.ride_confirmed == false && Time.now > ride.pickup_at
       # ride has not been confirmed and pickup time has passed, auto_confirm
       # go ahead and promote b/c we can't reach the voter

--- a/app/models/ride.rb
+++ b/app/models/ride.rb
@@ -88,14 +88,12 @@ class Ride < ApplicationRecord
       # disabling the bot previously disabled confirmation, but I think we need those regardless...
       if ride.conversation && ride.ride_zone
         
-        # If we have an email it was probably a scheduled ride, use it to send a notification.
         if ride.voter.present? && ride.voter.email.present?
           UserMailer.notify_scheduled_ride(ride).deliver_now
         end
         
         begin
           result = ride.conversation.send_confirmation
-          
           results[result] += 1
         rescue => e
           logger.error "Got error trying to confirm conversation #{ride.conversation.id}: #{e.message}"

--- a/app/models/ride.rb
+++ b/app/models/ride.rb
@@ -94,7 +94,8 @@ class Ride < ApplicationRecord
         end
         
         begin
-          result = ride.conversation.attempt_confirmation
+          result = ride.conversation.send_confirmation
+          
           results[result] += 1
         rescue => e
           logger.error "Got error trying to confirm conversation #{ride.conversation.id}: #{e.message}"

--- a/app/services/conversation_bot.rb
+++ b/app/services/conversation_bot.rb
@@ -218,7 +218,7 @@ class ConversationBot
     # Lifecycle: have language and name and confirmed origin and destination and confirmed time and passengers
     # Look for: special requests
     # And fini!
-    @conversation.update_attribute(:special_requests, @body)
+    @conversation.update_attribute(:special_requests, @body) unless @body.downcase.strip == 'none'
     Ride.create_from_conversation(@conversation)
     set_wait_response
     0
@@ -274,7 +274,7 @@ class ConversationBot
           @response = I18n.t(:no_address_match, locale: @locale)
           return @bot_counter + 1
         end
-
+        
         results = GooglePlaces.search(@body + ' ' + @conversation.ride_zone.state)
         if results.count == 1
           result = results.first

--- a/app/views/dispatch/_messages.html.haml
+++ b/app/views/dispatch/_messages.html.haml
@@ -1,4 +1,6 @@
-- if (@conversation.user.phone_number_normalized.present? && !@conversation.messages.empty?)
+-# Mashing haml around with js is not the way to do this.
+
+- if (@conversation&.user&.phone_number_normalized.present? && !@conversation.messages.empty?)
   .messages
     - @conversation.messages.order('created_at asc').each do |message|
       - if @conversation.user.phone_number_normalized.present?
@@ -12,7 +14,7 @@
           = message.body
 
 -# just to make the javascript below a little easier to read
-- if @conversation.ride.status == 'canceled'
+- if @conversation&.ride&.status == 'canceled'
   - close_button = ''
 - else
   - close_button = j( link_to "Archive Ride", '#', class: 'btn btn-xs btn-warning archive-convo' )
@@ -27,8 +29,20 @@
   - title = @conversation.from_phone.phony_formatted(normalize: :US, spaces: '-')
 - else
   - title = "#{h @conversation.user.name} <span>#{@conversation.user.phone_number_normalized.present? ? @conversation.user.phone_number.phony_formatted(normalize: :US, spaces: '-') : ''}</span>".html_safe
-
+  
+- if @conversation&.user&.phone_number_normalized.present?
+  - show_messages = "show();"
+  - no_phone = "hide();"
+- else
+  - show_messages = "hide();"
+  - no_phone = "show();"
+  
 :javascript
+  $('#conversation-messages').#{show_messages}
+  $('.msg-reply').#{show_messages}
+  $('.msg-reply').#{show_messages}
+  $('.no-phone').#{no_phone}
+  
   // now that we have the conversation object, populate the modal header
   $('#conv-modal-title').html( "#{title}" );
 

--- a/app/views/dispatch/_messages.html.haml
+++ b/app/views/dispatch/_messages.html.haml
@@ -1,6 +1,6 @@
 -# Mashing haml around with js is not the way to do this.
 
-- if (@conversation&.user&.phone_number_normalized.present? && !@conversation.messages.empty?)
+- if (@conversation&.user&.phone_number_normalized.present? && @conversation.messages.any?)
   .messages
     - @conversation.messages.order('created_at asc').each do |message|
       - if @conversation.user.phone_number_normalized.present?
@@ -23,26 +23,25 @@
   - block_button = j( link_to 'Unblock #', '#', class: 'btn btn-default btn-xs unblock-convo' )
 - else
   - block_button = j( link_to 'Block #', '#', class: 'btn btn-danger btn-xs block-convo' )
-  
+
 
 - if @conversation.user.name.include?('via sms')
   - title = @conversation.from_phone.phony_formatted(normalize: :US, spaces: '-')
 - else
   - title = "#{h @conversation.user.name} <span>#{@conversation.user.phone_number_normalized.present? ? @conversation.user.phone_number.phony_formatted(normalize: :US, spaces: '-') : ''}</span>".html_safe
-  
+
 - if @conversation&.user&.phone_number_normalized.present?
   - show_messages = "show();"
   - no_phone = "hide();"
 - else
   - show_messages = "hide();"
   - no_phone = "show();"
-  
+
 :javascript
   $('#conversation-messages').#{show_messages}
   $('.msg-reply').#{show_messages}
-  $('.msg-reply').#{show_messages}
   $('.no-phone').#{no_phone}
-  
+
   // now that we have the conversation object, populate the modal header
   $('#conv-modal-title').html( "#{title}" );
 
@@ -66,7 +65,7 @@
     }
     e.preventDefault();
   });
-  
+
   $('.unblock-convo').click(function(e) {
     if (confirm("Are you sure you want to unblock phone number #{@conversation.from_phone}?" )) {
       $.post( "#{unblacklist_voter_phone_admin_conversation_path(@conversation)}", function(responseData, status, xhr) {
@@ -77,7 +76,7 @@
     }
     e.preventDefault();
   });
-  
+
   $('.block-convo').click(function(e) {
     if (confirm("Are you sure you want to permanently block this phone number, #{@conversation.from_phone}?" )) {
       $.post( "#{blacklist_voter_phone_admin_conversation_path(@conversation)}", function(responseData, status, xhr) {

--- a/app/views/dispatch/_modal.html.haml
+++ b/app/views/dispatch/_modal.html.haml
@@ -1,3 +1,6 @@
+-# Most of the content that will fill below gets jacked in by the javascript in _messages.html.haml
+-# since it's only after a ride has been clicked on that we'll know what belongs here.
+
 .modal.fade.modal-body#conv-modal{"aria-labelledby" => "conv-modal-title", :role => "dialog", :tabindex => "-1"}
   .modal-dialog.modal-lg{:role => "document"}
     .modal-content
@@ -19,14 +22,12 @@
 
             %td{style: 'width: 340px;'}
               #conversation-messages
-
-              - if @conversation
-                .msg-reply
-                  #msg-input{ contenteditable: true}
-                  = button_tag 'Send', id: 'msg-submit', class: 'btn btn-send btn-primary btn-xs pull-right'
-              - else
-                %p
-                  = 'No number on record for this voter. No messages available.'
+              .msg-reply
+                #msg-input{ contenteditable: true}
+                = button_tag 'Send', id: 'msg-submit', class: 'btn btn-send btn-primary btn-xs pull-right'
+              %p.no-phone
+                No number on record for this voter.
+                
           %tr
             %td
             %td

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,12 +60,6 @@ en:
   how_to_help: 'How to Help'
   how_to_help_copy1: 'If you have a car and can be in'
   how_to_help_copy2:  'on election day, volunteer to be a driver! Help get voters to the polls on November 6th and make sure everyone has a vote.'
-
-# home2: 'You can sign up as either a driver or a passenger--or just join the community to get information about where you polling place is, who your elected officials are, and whose running for office in your community.'
-# election_is_on: 'The 2016 Election is on'
-# election_date: 'Tuesday, November 6'
-# thats: "That's"
-# days_away: 'days from now'
   will_drive: "Volunteer to Drive"
   will_drive_signup_description: "Drive the Vote will send you a confirmation after you sign up, and contact you before the election with more information."
   i_need_ride: "Request a Ride"
@@ -110,7 +104,7 @@ en:
 
   what_is_your_name: 'Thanks! What is your name?'
   empty_need_name: "Sorry, I didn't get a response. What is your name?"
-  bot_stalled: "I'm sorry, I don't understand. Someone will contact you soon"
+  bot_stalled: "Someone will assist you shortly."
   what_is_pickup_location: 'Hello %{name}. Where do you want to be picked up - address and city?'
   ride_too_far: 'That address is too far away. Please try again.'
   too_many_addresses: "Too many matches! Please reply with specific address and city or reply \"don't know\" or \"skip\"."
@@ -127,6 +121,7 @@ en:
   any_special_requests: 'What are your special requests (like wheelchair, car seats)? Or reply none.'
   thanks_will_contact: 'Thank you! We have your info and will contact you before your ride.'
   thanks_wait_for_driver: 'Thank you! We have your info and will contact you when we find a driver for you.'
+  auto_confirmed_wait_for_driver: "Your Drive the Vote ride is scheduled for %{time}. You don't need to do anything. Reply with 4 if you need to speak to someone"
   canceled_thanks_for_using: 'At your request, your ride has been canceled. Thanks for trying Drive the Vote'
   confirm_ride: 'Your Drive the Vote ride is scheduled for %{time}. Reply 1 to confirm, 2 to reschedule, 3 to cancel, 4 to speak to someone'
   ride_not_confirmed: 'Sorry we did not hear from you. Someone will contact you.'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -121,7 +121,7 @@ en:
   any_special_requests: 'What are your special requests (like wheelchair, car seats)? Or reply none.'
   thanks_will_contact: 'Thank you! We have your info and will contact you before your ride.'
   thanks_wait_for_driver: 'Thank you! We have your info and will contact you when we find a driver for you.'
-  auto_confirmed_wait_for_driver: "Your Drive the Vote ride is scheduled for %{time}. You don't need to do anything. Reply with 4 if you need to speak to someone"
+  auto_confirmed_wait_for_driver: "Your Drive the Vote ride is scheduled for %{time}. You don't need to do anything. Reply with 4 if you need to speak to someone."
   canceled_thanks_for_using: 'At your request, your ride has been canceled. Thanks for trying Drive the Vote'
   confirm_ride: 'Your Drive the Vote ride is scheduled for %{time}. Reply 1 to confirm, 2 to reschedule, 3 to cancel, 4 to speak to someone'
   ride_not_confirmed: 'Sorry we did not hear from you. Someone will contact you.'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -55,11 +55,6 @@ es:
   how_to_help: 'Cómo ayudar'
   how_to_help_copy1: 'Si usted tiene un coche y puede estar en'
   how_to_help_copy2: 'el día de la elección, voluntario para ser un conductor! Ayudar a conseguir que los votantes a las urnas el 8 de noviembre y asegurarse de que todo el mundo tiene un voto.'
-
-# election_is_on: 'La elección presidencial de 2016 es el'
-# election_date: 'martes, 8 de noviembre'
-# thats: 'Eso es '
-# days_away: 'días a partir de ahora'
   will_drive: "Puedo manejar"
   will_drive_signup_description: "Conducir para votar le enviará una confirmación después de su inscripción, y se ponga en contacto antes de la elección con más información."
   i_need_ride: "Necesito que me lleven"
@@ -105,7 +100,7 @@ es:
 
   what_is_your_name: '¡Gracias! ¿Cuál es su nombre?'
   empty_need_name: 'Lo sentimos, por favor, responda con su nombre'
-  bot_stalled: 'Lo siento, no compredo. Alguien se pondrá en contacto en breve'
+  bot_stalled: 'Alguien se pondrá en contacto en breve'
   what_is_pickup_location: 'Hola %{name}. ¿Dónde desea ser recogido - dirección y la ciudad?'
   ride_too_far: 'Esa dirección es demasiado lejos. Por favor, inténtelo de nuevo.'
   too_many_addresses: 'Demasiados partidos! Por favor, responda todas las direcciones y ciudad específica o responder "no sé" o "omitir"'
@@ -122,6 +117,7 @@ es:
   any_special_requests: '¿Cuáles son sus peticiones especiales (como silla de ruedas, asientos de bebé)? O responder ninguno.'
   thanks_will_contact: '¡Gracias! Tenemos su información y nos pondremos en contacto con usted antes de su viaje.'
   thanks_wait_for_driver: '¡Gracias! Tenemos su información y nos pondremos en contacto con usted cuando nos encontramos con un conductor para usted.'
+  auto_confirmed_wait_for_driver: "Su viaje is scheduled for %{time}. You don't need to do anything. Responda 4 para hablar con alguien"
   canceled_thanks_for_using: 'A su solicitud, su viaje ha sido cancelado. Gracias por intentar Conduzca el Voto.'
   confirm_ride: 'Su paseo está programado para %{time}. Responda 1 para confirmar, 2 para reprogramar, 3 para cancelar, 4 para hablar con alguien.'
   ride_not_confirmed: 'Lo siento, no escuchamos de usted. Alguien se pondrá en contacto con usted.'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -117,7 +117,7 @@ es:
   any_special_requests: '¿Cuáles son sus peticiones especiales (como silla de ruedas, asientos de bebé)? O responder ninguno.'
   thanks_will_contact: '¡Gracias! Tenemos su información y nos pondremos en contacto con usted antes de su viaje.'
   thanks_wait_for_driver: '¡Gracias! Tenemos su información y nos pondremos en contacto con usted cuando nos encontramos con un conductor para usted.'
-  auto_confirmed_wait_for_driver: "Su viaje is scheduled for %{time}. You don't need to do anything. Responda 4 para hablar con alguien"
+  auto_confirmed_wait_for_driver: "Su viaje de Drive the Vote está programado para %{time}.  No necesitas hacer nada. Responde con 4 si necesitas hablar con alguien."
   canceled_thanks_for_using: 'A su solicitud, su viaje ha sido cancelado. Gracias por intentar Conduzca el Voto.'
   confirm_ride: 'Su paseo está programado para %{time}. Responda 1 para confirmar, 2 para reprogramar, 3 para cancelar, 4 para hablar con alguien.'
   ride_not_confirmed: 'Lo siento, no escuchamos de usted. Alguien se pondrá en contacto con usted.'

--- a/spec/models/ride_spec.rb
+++ b/spec/models/ride_spec.rb
@@ -341,7 +341,7 @@ RSpec.describe Ride, type: :model do
       Ride.create_from_conversation(c2).update_attribute(:status, :waiting_assignment)
       Ride.create_from_conversation(c3)
       stub_const('Ride::SWITCH_TO_WAITING_ASSIGNMENT', 30) # only c1 should now match
-      expect_any_instance_of(Conversation).to receive(:attempt_confirmation).once
+      expect_any_instance_of(Conversation).to receive(:send_confirmation).once
       Ride.confirm_scheduled_rides
       expect(c1.reload.status).to eq('ride_created')
     end


### PR DESCRIPTION
When a scheduled ride is moved into 'waiting_assignment' status by the cron/scheduled lambda it needs to send the user a notification, which this PR adds. It also fixes an issue with the messages in the conversation modal