### PR TITLE
Upgrade loofah gem for CVE-2018-16468

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'geokit-rails', '2.3.1'
 gem 'google-api-client', '0.10.1'
 gem 'haml-rails', '1.0.0'
 gem 'humane-rails'
+gem 'loofah', '2.2.3' # https://github.com/flavorjones/loofah/issues/154
 gem 'nokogiri'
 gem 'pg', '1.0.0'
 gem 'phony_rails', '0.14.5' # <---------------- UPGRADING THIS to 0.14.7 BROKE HALF THE FUCKING SPECS.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,7 +161,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.2.2)
+    loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -387,6 +387,7 @@ DEPENDENCIES
   hirb (~> 0.7.3)
   humane-rails
   listen (>= 3.0.5, < 3.2)
+  loofah (= 2.2.3)
   nokogiri
   pg (= 1.0.0)
   phony_rails (= 0.14.5)


### PR DESCRIPTION
Only change to the gem was to patch an XSS issue, safe upgrade. We were alerted by Github.