### PR TITLE
fix status change bug, tweak drivers page

### DIFF
--- a/app/models/ride.rb
+++ b/app/models/ride.rb
@@ -82,11 +82,10 @@ class Ride < ApplicationRecord
   def self.confirm_scheduled_rides
     results = Hash.new(0)
     Ride.where(status: :scheduled).where('pickup_at < ?', SWITCH_TO_WAITING_ASSIGNMENT.minutes.from_now).each do |ride|
+      if ride.conversation && ride.ride_zone && ride.voter.present?
+        ride.update_attributes(status: :waiting_assignment)
 
-      # disabling the bot previously disabled confirmation, but I think we need those regardless...
-      if ride.conversation && ride.ride_zone
-
-        if ride.voter.present? && ride.voter.email.present?
+        if ride.voter.email.present?
           UserMailer.notify_scheduled_ride(ride).deliver_now
         end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -174,6 +174,10 @@ class User < ApplicationRecord
     self.has_role?(:admin)
   end
 
+  def is_zone_or_super_admin?
+    is_super_admin? || is_zone_admin?
+  end
+
   def is_zone_admin?
     RideZone.find_roles(:admin, self).present?
   end

--- a/app/views/dispatch/drivers.html.haml
+++ b/app/views/dispatch/drivers.html.haml
@@ -47,10 +47,16 @@
         email
       %td
         phone
-      %td
-        signed up
-      - if current_user.has_role?(:admin, @ride_zone) || current_user.is_super_admin?
+      - if current_user.is_zone_or_super_admin?
         %td
+          signed up
+      %td
+        last active
+
+      - if current_user.is_zone_or_super_admin?
+        %td
+      %td
+
     - if @drivers&.size > 0
       - @drivers.each do |driver|
         %tr
@@ -63,20 +69,24 @@
             = mail_to driver.email
           %td
             = tel_to  driver.phone_number.phony_formatted(normalize: :US, spaces: '-')
-          %td.created_at
-            = driver.created_at.in_time_zone(@ride_zone.time_zone).strftime("%-m/%-d %l:%M%P")
 
-          - if current_user.has_role?(:admin, @ride_zone) || current_user.is_super_admin?
+          - if current_user.is_zone_or_super_admin?
+            %td.created_at
+              = driver.created_at.in_time_zone(@ride_zone.time_zone).strftime("%-m/%-d %l:%M%P")
+          %td.last_active
+            = driver.updated_at.in_time_zone(@ride_zone.time_zone).strftime("%l:%M%P, %-m/%-d")
+
+          - if current_user.is_zone_or_super_admin?
             %td
               = link_to 'demote', change_role_admin_ride_zone_path(@ride_zone, to_role: 'unassigned_driver', driver: driver.id), method: :post
-            %td
-              - if driver.available?
-                -# pause-button emoji
-                - if driver.active_ride.present?
-                  %span.no-off-duty{title: "cannot take driver off duty mid-ride"}
-                    &#9208;
-                - else
-                  = link_to raw('&#9208;'), toggle_available_admin_driver_path(id: driver.id), method: :post, title: "take driver off duty"
+          %td
+            - if driver.available?
+              -# pause-button emoji
+              - if driver.active_ride.present?
+                %span.no-off-duty{title: "Cannot take driver off duty mid-ride"}
+                  = link_to raw('&#9208;'), '#', onClick="You can't take a driver off duty mid-ride. If you think they just forgot to mark their last ride complete, please call and ask them to do so."
+              - else
+                = link_to raw('&#9208;'), toggle_available_admin_driver_path(id: driver.id), method: :post, title: "Take driver off duty"
 
     - else
       %tr

--- a/spec/models/ride_spec.rb
+++ b/spec/models/ride_spec.rb
@@ -29,6 +29,21 @@ RSpec.describe Ride, type: :model do
     end
   end
 
+  describe "confirm_scheduled_rides" do
+    let(:scheduled_ride) { create :scheduled_ride, pickup_at: 10.minutes.from_now, conversation: create(:conversation) }
+
+    it "gets confirmed" do
+      Ride::SWITCH_TO_WAITING_ASSIGNMENT = 5
+      scheduled_ride.update_attributes(status: :scheduled)
+      Ride::SWITCH_TO_WAITING_ASSIGNMENT = 10
+
+      expect(scheduled_ride.status).to eq('scheduled')
+      Ride.confirm_scheduled_rides
+      expect(scheduled_ride.reload.status).to eq('waiting_assignment')
+    end
+
+  end
+
   describe 'radius validation' do
     let!(:zone) { create :ride_zone, latitude: 40.409, longitude: -80.09, max_pickup_radius: 5 }
 


### PR DESCRIPTION
Ride.confirm_scheduled_rides was sending notifications, but not changing status. Also updated dispatch /drivers page to make it easier to see when a driver is inactive, and may have just forgotten to check out.