### PR TITLE
Fix email time zone issue, relax state validation

### DIFF
--- a/app/models/ride.rb
+++ b/app/models/ride.rb
@@ -30,11 +30,11 @@ class Ride < ApplicationRecord
   validates :name, length: { maximum: 50 }
   validates :from_address, length: { maximum: 100 }
   validates :from_city, length: { maximum: 50 }
-  validates :from_state, length: { maximum: 2 }
+  # validates :from_state, length: { maximum: 2 }
   validates :from_zip, length: { maximum: 15 }
   validates :to_address, length: { maximum: 100 }
   validates :to_city, length: { maximum: 50 }
-  validates :to_state, length: { maximum: 2 }
+  # validates :to_state, length: { maximum: 2 }
   validates :to_zip, length: { maximum: 15 }
   validates :phone_number, length: { maximum: 17 }
   validates :email, length: { maximum: 50 }

--- a/app/models/ride.rb
+++ b/app/models/ride.rb
@@ -30,11 +30,11 @@ class Ride < ApplicationRecord
   validates :name, length: { maximum: 50 }
   validates :from_address, length: { maximum: 100 }
   validates :from_city, length: { maximum: 50 }
-  # validates :from_state, length: { maximum: 2 }
+  validates :from_state, length: { maximum: 50 }
   validates :from_zip, length: { maximum: 15 }
   validates :to_address, length: { maximum: 100 }
   validates :to_city, length: { maximum: 50 }
-  # validates :to_state, length: { maximum: 2 }
+  validates :to_state, length: { maximum: 50 }
   validates :to_zip, length: { maximum: 15 }
   validates :phone_number, length: { maximum: 17 }
   validates :email, length: { maximum: 50 }

--- a/app/views/user_mailer/notify_scheduled_ride.html.erb
+++ b/app/views/user_mailer/notify_scheduled_ride.html.erb
@@ -1,6 +1,6 @@
 Hi <%= @user.name %>,<br /><br />
 
-Your ride to your polling place is scheduled for today at <%= @ride.pickup_at.strftime('%I:%M%P') %>. You'll receive a separate notification when a driver has been assigned to you.<br /><br />
+Your ride to your polling place is scheduled for today at <%= @ride.pickup_in_time_zone.strftime('%I:%M%P') %>. You'll receive a separate notification when a driver has been assigned to you.<br /><br />
 
 If you still want a ride, do nothing. If you want to cancel or reschedule your ride, please send a text message to <%= @ride.ride_zone.phone_number.phony_formatted(format: :national) %>, or email <%= @ride.ride_zone.email %>.<br /><br />
 

--- a/spec/models/ride_spec.rb
+++ b/spec/models/ride_spec.rb
@@ -10,11 +10,11 @@ RSpec.describe Ride, type: :model do
 
   it { should validate_length_of(:from_address).is_at_most(100)}
   it { should validate_length_of(:from_city).is_at_most(50)}
-  it { should validate_length_of(:from_state).is_at_most(2)}
+  it { should validate_length_of(:from_state).is_at_most(50)}
   it { should validate_length_of(:from_zip).is_at_most(15)}
   it { should validate_length_of(:to_address).is_at_most(100)}
   it { should validate_length_of(:to_city).is_at_most(50)}
-  it { should validate_length_of(:to_state).is_at_most(2)}
+  it { should validate_length_of(:to_state).is_at_most(50)}
   it { should validate_length_of(:to_zip).is_at_most(15)}
 
   describe 'assignable?' do


### PR DESCRIPTION
Two very small changes:

- Remove the validation on Ride state fields that required it to be two characters, to allow the handling of full state names, since in some cases the Google Places API, which we're using for the city/state autocomplete on the ride scheduling form, will return the state name instead of abbreviation. See screenshot below.

- Add standard DtV time zone handling to the email notification that a scheduled ride is coming soon, so it doesn't look like it's coming in 8 hours.

<img width="398" alt="screen shot 2018-11-04 at 5 02 02 pm" src="https://user-images.githubusercontent.com/1668/47985968-270ee480-e090-11e8-80b5-f173c1a5bdcd.png">
